### PR TITLE
Session cache: use UTC consistently

### DIFF
--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -117,7 +117,7 @@ func (sc *SessionCache) GetSession(region string, s AWSDatasourceSettings) (*ses
 	}
 
 	duration := stscreds.DefaultDuration
-	expiration := time.Now().Add(duration)
+	expiration := time.Now().UTC().Add(duration)
 	if s.AssumeRoleARN != "" {
 		// We should assume a role in AWS
 		plog.Debug("Trying to assume role in AWS", "arn", s.AssumeRoleARN)


### PR DESCRIPTION

Local time: https://github.com/grafana/grafana-aws-sdk/blob/main/pkg/awsds/sessions.go#L120
UTC time:  https://github.com/grafana/grafana-aws-sdk/blob/main/pkg/awsds/sessions.go#L74