### PR TITLE
Add proper backward compatible cases when unmarshaling authType

### DIFF
--- a/pkg/awsds/settings.go
+++ b/pkg/awsds/settings.go
@@ -47,16 +47,16 @@ func (at *AuthType) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	switch j {
+	case "credentials": // Old name
+		fallthrough
 	case "sharedCreds":
 		*at = AuthTypeSharedCreds
 	case "keys":
 		*at = AuthTypeKeys
-	case "credentials": // This was the old name for default
-		fallthrough
 	case "default":
 		fallthrough
 	default:
-		*at = AuthTypeDefault // Credentials
+		*at = AuthTypeDefault // For old 'arn' option
 	}
 	return nil
 }


### PR DESCRIPTION
Seems like this is the correct mapping for older option names but if any data source is already using this they may rely on the older mapping in some way. But I assume only other one that needs to be checked besides x-ray is timescale.