### PR TITLE
Add SigV4 middleware

### DIFF
--- a/pkg/sigv4/sigv4.go
+++ b/pkg/sigv4/sigv4.go
@@ -1,0 +1,161 @@
+package models
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/session"
+	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
+	"github.com/aws/aws-sdk-go/private/protocol/rest"
+)
+
+type AuthType string
+
+const (
+	Default     AuthType = "default"
+	Keys        AuthType = "keys"
+	Credentials AuthType = "credentials"
+)
+
+// Host header is likely not necessary here
+// (see https://github.com/golang/go/blob/cad6d1fef5147d31e94ee83934c8609d3ad150b7/src/net/http/request.go#L92)
+// but adding for completeness
+var permittedHeaders = map[string]struct{}{
+	"Host":            {},
+	"Uber-Trace-Id":   {},
+	"User-Agent":      {},
+	"Accept":          {},
+	"Accept-Encoding": {},
+}
+
+type SigV4Middleware struct {
+	Config *Config
+	Next   http.RoundTripper
+}
+
+type Config struct {
+	AuthType string
+
+	Profile string
+
+	DatasourceType string
+
+	AccessKey string
+	SecretKey string
+
+	AssumeRoleARN string
+	ExternalID    string
+	Region        string
+}
+
+func (m *SigV4Middleware) RoundTrip(req *http.Request) (*http.Response, error) {
+	_, err := m.signRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if m.Next == nil {
+		return http.DefaultTransport.RoundTrip(req)
+	}
+
+	return m.Next.RoundTrip(req)
+}
+
+func (m *SigV4Middleware) signRequest(req *http.Request) (http.Header, error) {
+	signer, err := m.signer()
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := replaceBody(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if strings.Contains(req.URL.RawPath, "%2C") {
+		req.URL.RawPath = rest.EscapePath(req.URL.RawPath, false)
+	}
+
+	stripHeaders(req)
+
+	return signer.Sign(req, bytes.NewReader(body), awsServiceNamespace(m.Config.DatasourceType), m.Config.Region, time.Now().UTC())
+}
+
+func (m *SigV4Middleware) signer() (*v4.Signer, error) {
+	authType := AuthType(m.Config.AuthType)
+
+	var c *credentials.Credentials
+	switch authType {
+	case Keys:
+		c = credentials.NewStaticCredentials(m.Config.AccessKey, m.Config.SecretKey, "")
+	case Credentials:
+		c = credentials.NewSharedCredentials("", m.Config.Profile)
+	case Default:
+		// passing nil credentials will force AWS to allow a more complete credential chain vs the explicit default
+		s, err := session.NewSession(&aws.Config{
+			Region: aws.String(m.Config.Region),
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		if m.Config.AssumeRoleARN != "" {
+			return v4.NewSigner(stscreds.NewCredentials(s, m.Config.AssumeRoleARN)), nil
+		}
+
+		return v4.NewSigner(s.Config.Credentials), nil
+	case "":
+		return nil, fmt.Errorf("invalid SigV4 auth type")
+	}
+
+	if m.Config.AssumeRoleARN != "" {
+		s, err := session.NewSession(&aws.Config{
+			Region:      aws.String(m.Config.Region),
+			Credentials: c},
+		)
+		if err != nil {
+			return nil, err
+		}
+		return v4.NewSigner(stscreds.NewCredentials(s, m.Config.AssumeRoleARN)), nil
+	}
+
+	return v4.NewSigner(c), nil
+}
+
+func replaceBody(req *http.Request) ([]byte, error) {
+	if req.Body == nil {
+		return []byte{}, nil
+	}
+	payload, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	req.Body = ioutil.NopCloser(bytes.NewReader(payload))
+	return payload, nil
+}
+
+func awsServiceNamespace(dsType string) string {
+	switch dsType {
+	case "elasticsearch":
+		return "es"
+	case "prometheus":
+		return "aps"
+	default:
+		panic(fmt.Sprintf("Unsupported datasource %s", dsType))
+	}
+}
+
+func stripHeaders(req *http.Request) {
+	for h := range req.Header {
+		if _, exists := permittedHeaders[h]; !exists {
+			req.Header.Del(h)
+		}
+	}
+}

--- a/pkg/sigv4/sigv4.go
+++ b/pkg/sigv4/sigv4.go
@@ -45,7 +45,7 @@ type Config struct {
 
 	Profile string
 
-	DatasourceType string
+	Service string
 
 	AccessKey string
 	SecretKey string
@@ -85,7 +85,7 @@ func (m *SigV4Middleware) signRequest(req *http.Request) (http.Header, error) {
 
 	stripHeaders(req)
 
-	return signer.Sign(req, bytes.NewReader(body), awsServiceNamespace(m.Config.DatasourceType), m.Config.Region, time.Now().UTC())
+	return signer.Sign(req, bytes.NewReader(body), m.Config.Service, m.Config.Region, time.Now().UTC())
 }
 
 func (m *SigV4Middleware) signer() (*v4.Signer, error) {
@@ -139,17 +139,6 @@ func replaceBody(req *http.Request) ([]byte, error) {
 	}
 	req.Body = ioutil.NopCloser(bytes.NewReader(payload))
 	return payload, nil
-}
-
-func awsServiceNamespace(dsType string) string {
-	switch dsType {
-	case "elasticsearch":
-		return "es"
-	case "prometheus":
-		return "aps"
-	default:
-		panic(fmt.Sprintf("Unsupported datasource %s", dsType))
-	}
 }
 
 func stripHeaders(req *http.Request) {

--- a/pkg/sigv4/sigv4.go
+++ b/pkg/sigv4/sigv4.go
@@ -65,7 +65,7 @@ func (rt RoundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 		return rt(r)
 }
 
-// New instantiates a new signing middleware with an optional child
+// New instantiates a new signing middleware with an optional succeeding
 // middleware. The http.DefaultTransport will be used if nil
 func New(config *Config, next http.RoundTripper) http.RoundTripper {
 		return RoundTripperFunc(func(r *http.Request) (*http.Response, error) {

--- a/pkg/sigv4/sigv4.go
+++ b/pkg/sigv4/sigv4.go
@@ -62,21 +62,21 @@ type RoundTripperFunc func(req *http.Request) (*http.Response, error)
 
 // RoundTrip implements the RoundTripper interface.
 func (rt RoundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
-		return rt(r)
+	return rt(r)
 }
 
 // New instantiates a new signing middleware with an optional succeeding
 // middleware. The http.DefaultTransport will be used if nil
 func New(config *Config, next http.RoundTripper) http.RoundTripper {
-		return RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
-				if next == nil {
-						next = http.DefaultTransport
-				}
-				return (&middleware{
-						config: config,
-						next:   next,
-				}).exec(r)
-		})
+	return RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		if next == nil {
+			next = http.DefaultTransport
+		}
+		return (&middleware{
+			config: config,
+			next:   next,
+		}).exec(r)
+	})
 }
 
 func (m *middleware) exec(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/29738

Usage looks like:

```go
return sigv4.New(
    &Config{
        Service:        "es",
        AccessKey:      "blah",
        SecretKey:      "blah",
        Region:         "eu-central-1",
        AssumeRoleARN:  "", // optional
        AuthType:       "default",
        ExternalID:     "", // optional
        Profile:        "default",
   },
   nil, // optional subsequent middleware
)
```