### PR TITLE
export ConnectionConfigProps with generics

### DIFF
--- a/src/ConnectionConfig.tsx
+++ b/src/ConnectionConfig.tsx
@@ -13,14 +13,14 @@ import { awsAuthProviderOptions, standardRegions, AwsAuthDataSourceJsonData, Aws
 
 const toOption = (value: string) => ({ value, label: value });
 
-interface Props extends DataSourcePluginOptionsEditorProps<AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData> {
+export interface ConnectionConfigProps<J = AwsAuthDataSourceJsonData, S = AwsAuthDataSourceSecureJsonData> extends DataSourcePluginOptionsEditorProps<J,S> {
   standardRegions?: string[];
   loadRegions?: () => Promise<string[]>;
   defaultEndpoint?: string;
   children?: React.ReactNode;
 }
 
-export const ConnectionConfig: FC<Props> = (props: Props) => {
+export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionConfigProps) => {
   const [regions, setRegions] = useState((props.standardRegions || standardRegions).map(toOption));
 
   useEffect(() => {
@@ -151,6 +151,7 @@ export const ConnectionConfig: FC<Props> = (props: Props) => {
           defaultValue={options.jsonData.defaultRegion}
           allowCustomValue={true}
           onChange={onUpdateDatasourceJsonDataOptionSelect(props, 'defaultRegion')}
+          formatCreateLabel={(r) => `Use region: ${r}`}
         />
       </InlineField>
       {props.children}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { ConnectionConfig } from './ConnectionConfig';
+export { ConnectionConfig, ConnectionConfigProps } from './ConnectionConfig';
 export * from './types';
 export * from './regions';
 export * from './providers';


### PR DESCRIPTION
I took a stab at using the library for iot-sitewise, with this PR I was able to get things working here:
https://github.com/grafana/iot-sitewise-datasource/pull/85

In that PR there is an issue with type conflicts added in 7.5