### PR TITLE
Add Content-Type to sigv4 header allowlist

### DIFF
--- a/pkg/sigv4/sigv4.go
+++ b/pkg/sigv4/sigv4.go
@@ -28,6 +28,11 @@ var permittedHeaders = map[string]struct{}{
 	"User-Agent":      {},
 	"Accept":          {},
 	"Accept-Encoding": {},
+	"Content-Type":    {},
+	"Content-Length":  {},
+	"securitytenant":  {},
+	"sgtenant":        {},
+	"kbn-xsrf":        {},
 }
 
 var (


### PR DESCRIPTION
> Will need to keep in sync with these latest changes here https://github.com/grafana/grafana/pull/30115

_Originally posted by @wbrowne in https://github.com/grafana/grafana-aws-sdk/issues/4#issuecomment-757750871_

Fixes grafana/grafana#32548