### PR TITLE
include session token in key creds

### DIFF
--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -173,7 +173,7 @@ func (sc *SessionCache) GetSession(region string, s AWSDatasourceSettings) (*ses
 	case AuthTypeKeys:
 		plog.Debug("Authenticating towards AWS with an access key pair", "region", region)
 		cfgs = append(cfgs, &aws.Config{
-			Credentials: credentials.NewStaticCredentials(s.AccessKey, s.SecretKey, ""),
+			Credentials: credentials.NewStaticCredentials(s.AccessKey, s.SecretKey, s.SessionToken),
 		})
 	case AuthTypeDefault:
 		plog.Debug("Authenticating towards AWS with default SDK method", "region", region)

--- a/pkg/awsds/settings.go
+++ b/pkg/awsds/settings.go
@@ -98,8 +98,9 @@ type AWSDatasourceSettings struct {
 	DefaultRegion string `json:"defaultRegion"`
 
 	// Loaded from DecryptedSecureJSONData (not the json object)
-	AccessKey string `json:"-"`
-	SecretKey string `json:"-"`
+	AccessKey    string `json:"-"`
+	SecretKey    string `json:"-"`
+	SessionToken string `json:"-"`
 }
 
 // LoadSettings will read and validate Settings from the DataSourceConfg


### PR DESCRIPTION
This includes a param for adding a `sessionToken` value while authenticating with AWS using key pairs.