### PR TITLE
feature: support temporary security credentials

### DIFF
--- a/pkg/awsds/settings.go
+++ b/pkg/awsds/settings.go
@@ -121,6 +121,7 @@ func (s *AWSDatasourceSettings) Load(config backend.DataSourceInstanceSettings) 
 
 	s.AccessKey = config.DecryptedSecureJSONData["accessKey"]
 	s.SecretKey = config.DecryptedSecureJSONData["secretKey"]
+	s.SessionToken = config.DecryptedSecureJSONData["sessionToken"]
 
 	return nil
 }

--- a/pkg/sigv4/sigv4.go
+++ b/pkg/sigv4/sigv4.go
@@ -51,8 +51,9 @@ type Config struct {
 
 	Service string
 
-	AccessKey string
-	SecretKey string
+	AccessKey    string
+	SecretKey    string
+	SessionToken string
 
 	AssumeRoleARN string
 	ExternalID    string
@@ -139,7 +140,7 @@ func (m *middleware) signer() (*v4.Signer, error) {
 	var c *credentials.Credentials
 	switch authType {
 	case awsds.AuthTypeKeys:
-		c = credentials.NewStaticCredentials(m.config.AccessKey, m.config.SecretKey, "")
+		c = credentials.NewStaticCredentials(m.config.AccessKey, m.config.SecretKey, m.config.SessionToken)
 	case awsds.AuthTypeSharedCreds:
 		c = credentials.NewSharedCredentials("", m.config.Profile)
 	case awsds.AuthTypeEC2IAMRole:

--- a/src/ConnectionConfig.test.tsx
+++ b/src/ConnectionConfig.test.tsx
@@ -37,10 +37,12 @@ const getProps = (propOverrides?: object) => {
       secureJsonFields: {
         accessKey: false,
         secretKey: false,
+        sessionToken: false,
       },
       secureJsonData: {
         accessKey: '',
         secretKey: '',
+        sessionToken: '',
       },
     },
     onOptionsChange: jest.fn(),

--- a/src/ConnectionConfig.tsx
+++ b/src/ConnectionConfig.tsx
@@ -137,6 +137,26 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
               />
             )}
           </InlineField>
+
+          <InlineField label="Session Token" labelWidth={28}>
+            {props.options.secureJsonFields?.sessionToken ? (
+              <ButtonGroup className="width-30">
+                <Input disabled placeholder="Configured" />
+                <ToolbarButton
+                  icon="edit"
+                  type="button"
+                  tooltip="Edit Session Token"
+                  onClick={onUpdateDatasourceResetOption(props as any, 'sessionToken')}
+                />
+              </ButtonGroup>
+            ) : (
+              <Input
+                className="width-30"
+                value={options.secureJsonData?.sessionToken ?? ''}
+                onChange={onUpdateDatasourceSecureJsonDataOption(props, 'sessionToken')}
+              />
+            )}
+          </InlineField>
         </>
       )}
 

--- a/src/ConnectionConfig.tsx
+++ b/src/ConnectionConfig.tsx
@@ -137,26 +137,6 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
               />
             )}
           </InlineField>
-
-          <InlineField label="Session Token" labelWidth={28}>
-            {props.options.secureJsonFields?.sessionToken ? (
-              <ButtonGroup className="width-30">
-                <Input disabled placeholder="Configured" />
-                <ToolbarButton
-                  icon="edit"
-                  type="button"
-                  tooltip="Edit Session Token"
-                  onClick={onUpdateDatasourceResetOption(props as any, 'sessionToken')}
-                />
-              </ButtonGroup>
-            ) : (
-              <Input
-                className="width-30"
-                value={options.secureJsonData?.sessionToken ?? ''}
-                onChange={onUpdateDatasourceSecureJsonDataOption(props, 'sessionToken')}
-              />
-            )}
-          </InlineField>
         </>
       )}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,4 +23,5 @@ export interface AwsAuthDataSourceJsonData extends DataSourceJsonData {
 export interface AwsAuthDataSourceSecureJsonData {
   accessKey?: string;
   secretKey?: string;
+  sessionToken?: string;
 }


### PR DESCRIPTION
this includes support for using temporary key credentials for AWS resources. exposes the `sessionToken` param, which is needed for this case.

see:
https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#temporary-access-keys
and:
https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html
