### PR TITLE
Add the rest of backend sql packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.14
 
 require (
 	github.com/aws/aws-sdk-go v1.35.30
-	github.com/google/go-cmp v0.5.5
+	github.com/google/go-cmp v0.5.6
 	github.com/grafana/grafana-plugin-sdk-go v0.94.0
-	github.com/grafana/sqlds/v2 v2.3.0
+	github.com/grafana/sqlds/v2 v2.3.2
 	github.com/jpillora/backoff v1.0.0
 	github.com/magefile/mage v1.11.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,9 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -127,8 +128,8 @@ github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grafana/grafana-plugin-sdk-go v0.94.0 h1:S5Jk3QFzH2XXbVze9RDStwf/AjwpeDRUayVgC4LuczY=
 github.com/grafana/grafana-plugin-sdk-go v0.94.0/go.mod h1:3VXz4nCv6wH5SfgB3mlW39s+c+LetqSCjFj7xxPC5+M=
-github.com/grafana/sqlds/v2 v2.3.0 h1:6lR4oHvnytj3u8pfh+VxLTUwaefY0QKNStYeKHa4Wn0=
-github.com/grafana/sqlds/v2 v2.3.0/go.mod h1:strDuUDlraTB28OLTq9AK9pnohjkXqJjXJOFHQW7fH4=
+github.com/grafana/sqlds/v2 v2.3.2 h1:HiMPTn/g4CXPXjWYLc22KwKSK5yR2DyG0wr95M7giZM=
+github.com/grafana/sqlds/v2 v2.3.2/go.mod h1:34uyqPBWsEvg4V/xxh6V4uIqwu1qLfOfsmScll/ukrk=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
@@ -264,7 +265,6 @@ github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/sql/api/api.go
+++ b/pkg/sql/api/api.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
+	"github.com/grafana/grafana-aws-sdk/pkg/sql/models"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/sqlds/v2"
 	"github.com/jpillora/backoff"
@@ -42,6 +44,13 @@ type Resources interface {
 	Regions(aws.Context) ([]string, error)
 	Databases(aws.Context, sqlds.Options) ([]string, error)
 }
+
+type AWSAPI interface {
+	SQL
+	Resources
+}
+
+type Loader func(cache *awsds.SessionCache, settings models.Settings) (AWSAPI, error)
 
 var (
 	backoffMin = 200 * time.Millisecond

--- a/pkg/sql/datasource/datasource.go
+++ b/pkg/sql/datasource/datasource.go
@@ -13,18 +13,20 @@ import (
 	"github.com/grafana/sqlds/v2"
 )
 
-// AWSDatasource stores a cache of:
-// - config: base configuration per datasource (only datasource ID)
-// - db: database connection per datasource and connection args
-// - driver: driver instance per datasource and connection args
-// - api: API instace per datasource and connection args
-// - sessionCache: cache used to create connections
+// AWSDatasource stores a cache of several instances.
+// Each Map will depend on the datasource ID (and connection options):
+// - config: Base configuration. It will be used as base to populate datasource settings.
+//           It does not depend on connection options (only one per datasource)
+// - api: API instace with the common methods to contact the data source API.
+// - driver: Abstraction on top the upstream sql.Driver. Defined to handle multiple connections.
+// - db: Upstream database (sql.DB).
+// - sessionCache: AWS cache. This is not a Map since it does not depend on the datasource.
 type AWSDatasource struct {
-	config       sync.Map
-	db           sync.Map
-	driver       sync.Map
-	api          sync.Map
 	sessionCache *awsds.SessionCache
+	config       sync.Map
+	api          sync.Map
+	driver       sync.Map
+	db           sync.Map
 }
 
 func New(config backend.DataSourceInstanceSettings) *AWSDatasource {

--- a/pkg/sql/datasource/datasource_test.go
+++ b/pkg/sql/datasource/datasource_test.go
@@ -1,0 +1,287 @@
+package datasource
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
+	"github.com/grafana/grafana-aws-sdk/pkg/sql/api"
+	sqlDriver "github.com/grafana/grafana-aws-sdk/pkg/sql/driver"
+	"github.com/grafana/grafana-aws-sdk/pkg/sql/models"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/sqlds/v2"
+)
+
+func TestNew(t *testing.T) {
+	config := backend.DataSourceInstanceSettings{
+		ID: 100,
+	}
+	ds := New(config)
+	if ds.sessionCache == nil {
+		t.Errorf("missing initialization")
+	}
+	if _, ok := ds.config.Load(config.ID); !ok {
+		t.Errorf("missing config")
+	}
+}
+
+type fakeDriver struct {
+	db     *sql.DB
+	closed bool
+}
+
+func (f *fakeDriver) Open(_ string) (driver.Conn, error) {
+	return nil, nil
+}
+
+func (f *fakeDriver) Closed() bool {
+	return f.closed
+}
+
+func (f *fakeDriver) OpenDB() (*sql.DB, error) {
+	return f.db, nil
+}
+
+func TestLoadDB(t *testing.T) {
+	db := &sql.DB{}
+	tests := []struct {
+		description string
+		driver      *fakeDriver
+		res         *sql.DB
+	}{
+		{
+			description: "it should return a stored db",
+			driver:      &fakeDriver{db: db},
+			res:         db,
+		},
+		{
+			description: "it should not return a db if the connection has been closed",
+			driver:      &fakeDriver{closed: true, db: db},
+			res:         nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			id := int64(1)
+			args := sqlds.Options{}
+			key := connectionKey(id, args)
+			ds := &AWSDatasource{}
+			if tt.driver.db != nil {
+				ds.db.Store(key, tt.driver.db)
+				ds.driver.Store(key, tt.driver)
+			}
+			res, exists := ds.loadDB(id, args)
+			if res != tt.res {
+				t.Errorf("unexpected result %v", res)
+			}
+			if tt.res != nil && !exists {
+				t.Errorf("should return true")
+			}
+		})
+	}
+}
+
+type fakeAPI struct {
+	api.AWSAPI
+}
+
+func TestLoadAPI(t *testing.T) {
+	api := &fakeAPI{}
+	tests := []struct {
+		description string
+		id          int64
+		args        sqlds.Options
+		api         *fakeAPI
+		res         *fakeAPI
+	}{
+		{
+			description: "it should return a stored api without args",
+			id:          1,
+			args:        sqlds.Options{},
+			api:         api,
+			res:         api,
+		},
+		{
+			description: "it should return a stored api with args",
+			id:          1,
+			args:        sqlds.Options{"foo": "bar"},
+			api:         api,
+			res:         api,
+		},
+		{
+			description: "it should return an empty response",
+			id:          1,
+			args:        sqlds.Options{"foo": "bar"},
+			api:         nil,
+			res:         nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			ds := &AWSDatasource{}
+			key := connectionKey(tt.id, tt.args)
+			if tt.api != nil {
+				ds.api.Store(key, tt.api)
+			}
+			res, exists := ds.loadAPI(tt.id, tt.args)
+			if res != tt.res && (res != nil || tt.res != nil) {
+				t.Errorf("unexpected result %v", res)
+			}
+			if tt.res != nil && !exists {
+				t.Errorf("should return true")
+			}
+		})
+	}
+}
+
+type fakeSettings struct {
+	settings backend.DataSourceInstanceSettings
+	modifier sqlds.Options
+}
+
+func (f *fakeSettings) Load(c backend.DataSourceInstanceSettings) error {
+	f.settings = c
+	return nil
+}
+
+func (f *fakeSettings) Apply(args sqlds.Options) {
+	f.modifier = args
+}
+
+func TestParseSettings(t *testing.T) {
+	id := int64(1)
+	args := sqlds.Options{"foo": "bar"}
+	ds := &AWSDatasource{}
+	ds.config.Store(id, backend.DataSourceInstanceSettings{ID: id})
+
+	settings := &fakeSettings{}
+	err := ds.parseSettings(id, args, settings)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if settings.settings.ID != id {
+		t.Errorf("failed to load config")
+	}
+	if settings.modifier["foo"] != "bar" {
+		t.Errorf("failed to apply modifier")
+	}
+}
+
+func fakeAPILoader(cache *awsds.SessionCache, settings models.Settings) (api.AWSAPI, error) {
+	return fakeAPI{}, nil
+}
+
+func TestCreateAPI(t *testing.T) {
+	id := int64(1)
+	args := sqlds.Options{"foo": "bar"}
+	ds := &AWSDatasource{}
+	key := connectionKey(id, args)
+	settings := &fakeSettings{}
+
+	api, err := ds.createAPI(id, args, settings, fakeAPILoader)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if !cmp.Equal(api, fakeAPI{}) {
+		t.Errorf("unexpected result api %v", cmp.Diff(api, fakeAPI{}))
+	}
+	cachedAPI, ok := ds.api.Load(key)
+	if !ok || !cmp.Equal(cachedAPI, fakeAPI{}) {
+		t.Errorf("unexpected cached api %v", cmp.Diff(cachedAPI, fakeAPI{}))
+	}
+}
+
+func fakeDriverLoader(api.AWSAPI) (sqlDriver.Driver, error) {
+	return &fakeDriver{db: &sql.DB{}}, nil
+}
+
+func TestCreateDriver(t *testing.T) {
+	id := int64(1)
+	args := sqlds.Options{"foo": "bar"}
+	ds := &AWSDatasource{}
+	key := connectionKey(id, args)
+	api := fakeAPI{}
+	settings := &fakeSettings{}
+
+	dr, err := ds.createDriver(id, args, settings, api, fakeDriverLoader)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if dr == nil {
+		t.Errorf("unexpected result driver %v", dr)
+	}
+	cachedDriver, ok := ds.driver.Load(key)
+	if !ok || cachedDriver == nil {
+		t.Errorf("unexpected cached driver %v", cachedDriver)
+	}
+}
+
+func TestCreateDB(t *testing.T) {
+	id := int64(1)
+	args := sqlds.Options{"foo": "bar"}
+	ds := &AWSDatasource{}
+	key := connectionKey(id, args)
+	db := &sql.DB{}
+	dr := &fakeDriver{db: db}
+	settings := &fakeSettings{}
+
+	res, err := ds.createDB(id, args, settings, dr)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if res != db {
+		t.Errorf("unexpected result db %v", res)
+	}
+	cachedDB, ok := ds.db.Load(key)
+	if !ok || cachedDB != db {
+		t.Errorf("unexpected cached db %v", cachedDB)
+	}
+}
+
+func fakeSettingsLoader() models.Settings {
+	return &fakeSettings{}
+}
+
+func TestGetDB(t *testing.T) {
+	id := int64(1)
+	args := sqlds.Options{"foo": "bar"}
+	ds := &AWSDatasource{}
+	ds.config.Store(id, backend.DataSourceInstanceSettings{ID: id})
+	key := connectionKey(id, args)
+
+	res, err := ds.GetDB(id, args, fakeSettingsLoader, fakeAPILoader, fakeDriverLoader)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if res == nil {
+		t.Errorf("unexpected result db %v", res)
+	}
+	cachedDB, ok := ds.db.Load(key)
+	if !ok || cachedDB == nil {
+		t.Errorf("unexpected cached db %v", cachedDB)
+	}
+}
+
+func TestGetAPI(t *testing.T) {
+	id := int64(1)
+	args := sqlds.Options{"foo": "bar"}
+	ds := &AWSDatasource{}
+	ds.config.Store(id, backend.DataSourceInstanceSettings{ID: id})
+	key := connectionKey(id, args)
+
+	api, err := ds.GetAPI(id, args, fakeSettingsLoader, fakeAPILoader)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if !cmp.Equal(api, fakeAPI{}) {
+		t.Errorf("unexpected result api %v", cmp.Diff(api, fakeAPI{}))
+	}
+	cachedAPI, ok := ds.api.Load(key)
+	if !ok || !cmp.Equal(cachedAPI, fakeAPI{}) {
+		t.Errorf("unexpected cached api %v", cmp.Diff(cachedAPI, fakeAPI{}))
+	}
+}

--- a/pkg/sql/datasource/utils.go
+++ b/pkg/sql/datasource/utils.go
@@ -1,0 +1,21 @@
+package datasource
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter"
+	"github.com/grafana/sqlds/v2"
+)
+
+func connectionKey(id int64, args sqlds.Options) string {
+	return fmt.Sprintf("%d-%v", id, args)
+}
+
+func GetDatasourceID(ctx context.Context) int64 {
+	plugin := httpadapter.PluginConfigFromContext(ctx)
+	if plugin.DataSourceInstanceSettings != nil {
+		return plugin.DataSourceInstanceSettings.ID
+	}
+	return 0
+}

--- a/pkg/sql/datasource/utils_test.go
+++ b/pkg/sql/datasource/utils_test.go
@@ -1,0 +1,15 @@
+package datasource
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetDatasourceID(t *testing.T) {
+	// It's not possible to test that GetDatasourceID returns an actual
+	// ID because the ctx key is not exported. This just tests the fallback
+	// path.
+	if id := GetDatasourceID(context.TODO()); id != 0 {
+		t.Errorf("unexpected id: %d", id)
+	}
+}

--- a/pkg/sql/driver/driver.go
+++ b/pkg/sql/driver/driver.go
@@ -1,0 +1,16 @@
+package driver
+
+import (
+	"database/sql"
+	"database/sql/driver"
+
+	"github.com/grafana/grafana-aws-sdk/pkg/sql/api"
+)
+
+type Driver interface {
+	Open(_ string) (driver.Conn, error)
+	Closed() bool
+	OpenDB() (*sql.DB, error)
+}
+
+type Loader func(api.AWSAPI) (Driver, error)

--- a/pkg/sql/models/models.go
+++ b/pkg/sql/models/models.go
@@ -1,0 +1,15 @@
+package models
+
+import (
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/sqlds/v2"
+)
+
+type Settings interface {
+	Load(backend.DataSourceInstanceSettings) error
+	Apply(args sqlds.Options)
+}
+
+type Loader func() Settings
+
+const DefaultKey = "__default"


### PR DESCRIPTION
Package for AWS SQL data sources that define common routes.

Epic at #28
Design [doc](https://docs.google.com/document/d/1V3SJGER5zIEQ_x-jHTE3gUIOvDMYqeYFsG4jxtTdux4/edit#)
Closes #31 

This PR implements, mainly, the `AWSDatasource` struct. The goal of this entity is to provide the methods to retrieve a database or an API instance, supporting multiple connections at the same time. The main concepts are:

 - Settings. This is the data source settings. It extends the basic AWS configuration (`backend.DataSourceInstanceSettings`) with settings specific to the data source.
 - API. An interface with the common methods to contact the data source API (implemented at #29).
 - Driver. Abstraction on top the the upstream sql.Driver. Defined to handle multiple connections. It's main purpose is to return databases.
 - Database. Upstream `sql.DB`.

The key point here is that the data source using this library should only worry about defining methods to initialize settings, APIs, databases... and forget about how to handle multiple connections.
