### PR TITLE
Chore: small improvements

### DIFF
--- a/pkg/sql/datasource/datasource.go
+++ b/pkg/sql/datasource/datasource.go
@@ -29,10 +29,13 @@ type AWSDatasource struct {
 	db           sync.Map
 }
 
-func New(config backend.DataSourceInstanceSettings) *AWSDatasource {
+func New() *AWSDatasource {
 	ds := &AWSDatasource{sessionCache: awsds.NewSessionCache()}
-	ds.config.Store(config.ID, config)
 	return ds
+}
+
+func (d *AWSDatasource) StoreConfig(config backend.DataSourceInstanceSettings) {
+	d.config.Store(config.ID, config)
 }
 
 func (d *AWSDatasource) storeDB(id int64, args sqlds.Options, db *sql.DB) {

--- a/pkg/sql/datasource/datasource_test.go
+++ b/pkg/sql/datasource/datasource_test.go
@@ -15,13 +15,18 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	config := backend.DataSourceInstanceSettings{
-		ID: 100,
-	}
-	ds := New(config)
+	ds := New()
 	if ds.sessionCache == nil {
 		t.Errorf("missing initialization")
 	}
+}
+
+func TestStoreConfig(t *testing.T) {
+	config := backend.DataSourceInstanceSettings{
+		ID: 100,
+	}
+	ds := &AWSDatasource{}
+	ds.StoreConfig(config)
 	if _, ok := ds.config.Load(config.ID); !ok {
 		t.Errorf("missing config")
 	}

--- a/pkg/sql/routes/routes.go
+++ b/pkg/sql/routes/routes.go
@@ -35,7 +35,7 @@ func ParseBody(body io.ReadCloser) (sqlds.Options, error) {
 	return reqBody, nil
 }
 
-func SendResources(rw http.ResponseWriter, res []string, err error) {
+func SendResources(rw http.ResponseWriter, res interface{}, err error) {
 	if err != nil {
 		rw.WriteHeader(http.StatusBadRequest)
 		Write(rw, []byte(err.Error()))


### PR DESCRIPTION
- SQL Datasource: Separate configuration storing from instance initialization.
- SQL Routes: Allow to send any resource, not only `[]string`