### PR TITLE
SQL data source: expose Init method

### DIFF
--- a/pkg/sql/datasource/datasource.go
+++ b/pkg/sql/datasource/datasource.go
@@ -34,7 +34,7 @@ func New() *AWSDatasource {
 	return ds
 }
 
-func (d *AWSDatasource) StoreConfig(config backend.DataSourceInstanceSettings) {
+func (d *AWSDatasource) storeConfig(config backend.DataSourceInstanceSettings) {
 	d.config.Store(config.ID, config)
 }
 
@@ -104,7 +104,7 @@ func (s *AWSDatasource) createDriver(id int64, args sqlds.Options, settings mode
 func (d *AWSDatasource) parseSettings(id int64, args sqlds.Options, settings models.Settings) error {
 	config, ok := d.config.Load(id)
 	if !ok {
-		return fmt.Errorf("unable to find stored configuration for datasource %d", id)
+		return fmt.Errorf("unable to find stored configuration for datasource %d. Initialize it first", id)
 	}
 	err := settings.Load(config.(backend.DataSourceInstanceSettings))
 	if err != nil {
@@ -112,6 +112,11 @@ func (d *AWSDatasource) parseSettings(id int64, args sqlds.Options, settings mod
 	}
 	settings.Apply(args)
 	return nil
+}
+
+// Init stores the data source configuration. It's needed for the GetDB and GetAPI functions
+func (s *AWSDatasource) Init(config backend.DataSourceInstanceSettings) {
+	s.storeConfig(config)
 }
 
 // GetDB returns a *sql.DB. When called multiple times with the same id and options, it

--- a/pkg/sql/datasource/datasource_test.go
+++ b/pkg/sql/datasource/datasource_test.go
@@ -21,12 +21,12 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func TestStoreConfig(t *testing.T) {
+func TestInit(t *testing.T) {
 	config := backend.DataSourceInstanceSettings{
 		ID: 100,
 	}
 	ds := &AWSDatasource{}
-	ds.StoreConfig(config)
+	ds.Init(config)
 	if _, ok := ds.config.Load(config.ID); !ok {
 		t.Errorf("missing config")
 	}
@@ -255,10 +255,11 @@ func TestGetDB(t *testing.T) {
 	id := int64(1)
 	args := sqlds.Options{"foo": "bar"}
 	ds := &AWSDatasource{}
-	ds.config.Store(id, backend.DataSourceInstanceSettings{ID: id})
+	config := backend.DataSourceInstanceSettings{ID: id}
+	ds.Init(config)
 	key := connectionKey(id, args)
 
-	res, err := ds.GetDB(id, args, fakeSettingsLoader, fakeAPILoader, fakeDriverLoader)
+	res, err := ds.GetDB(config.ID, args, fakeSettingsLoader, fakeAPILoader, fakeDriverLoader)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
@@ -275,7 +276,8 @@ func TestGetAPI(t *testing.T) {
 	id := int64(1)
 	args := sqlds.Options{"foo": "bar"}
 	ds := &AWSDatasource{}
-	ds.config.Store(id, backend.DataSourceInstanceSettings{ID: id})
+	config := backend.DataSourceInstanceSettings{ID: id}
+	ds.Init(config)
 	key := connectionKey(id, args)
 
 	api, err := ds.GetAPI(id, args, fakeSettingsLoader, fakeAPILoader)


### PR DESCRIPTION
Just some syntax sugar here. Rather than exposing the `StoreConfig` method, use an `Init` method instead.