### PR TITLE
a11y: Add missing aria labels on connection config component

### DIFF
--- a/src/ConnectionConfig.tsx
+++ b/src/ConnectionConfig.tsx
@@ -68,6 +68,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
     <FieldSet label={skipHeader ? '' : 'Connection Details'} data-testid="connection-config">
       <InlineField
         label="Authentication Provider"
+        aria-label="Authentication Provider"
         labelWidth={28}
         tooltip="Specify which AWS credentials chain to use."
       >
@@ -180,6 +181,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
       )}
       <InlineField
         label="Default Region"
+        aria-label="Default Region"
         labelWidth={28}
         tooltip="Specify the region, such as for US West (Oregon) use ` us-west-2 ` as the region."
       >

--- a/src/ConnectionConfig.tsx
+++ b/src/ConnectionConfig.tsx
@@ -68,11 +68,11 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
     <FieldSet label={skipHeader ? '' : 'Connection Details'} data-testid="connection-config">
       <InlineField
         label="Authentication Provider"
-        aria-label="Authentication Provider"
         labelWidth={28}
         tooltip="Specify which AWS credentials chain to use."
       >
         <Select
+          aria-label="Authentication Provider selection"
           className="width-30"
           value={currentProvider}
           options={awsAuthProviderOptions.filter((opt) => awsAllowedAuthProviders.includes(opt.value!))}
@@ -181,11 +181,11 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
       )}
       <InlineField
         label="Default Region"
-        aria-label="Default Region"
         labelWidth={28}
         tooltip="Specify the region, such as for US West (Oregon) use ` us-west-2 ` as the region."
       >
         <Select
+          aria-label="Default Region selection"
           className="width-30"
           value={regions.find((region) => region.value === options.jsonData.defaultRegion)}
           options={regions}

--- a/src/ConnectionConfig.tsx
+++ b/src/ConnectionConfig.tsx
@@ -72,7 +72,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
         tooltip="Specify which AWS credentials chain to use."
       >
         <Select
-          aria-label="Authentication Provider selection"
+          aria-label="Authentication Provider"
           className="width-30"
           value={currentProvider}
           options={awsAuthProviderOptions.filter((opt) => awsAllowedAuthProviders.includes(opt.value!))}
@@ -185,7 +185,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
         tooltip="Specify the region, such as for US West (Oregon) use ` us-west-2 ` as the region."
       >
         <Select
-          aria-label="Default Region selection"
+          aria-label="Default Region"
           className="width-30"
           value={regions.find((region) => region.value === options.jsonData.defaultRegion)}
           options={regions}


### PR DESCRIPTION
Accessibility improvement: tracked on https://github.com/grafana/grafana/issues/41206

Closes https://github.com/grafana/grafana/issues/42706

Hey @sarahzinger here's a go at adding aria-labels (indirectly?) for CloudWatch. Not sure at all if that's correct. Let me know what you think.
