### PR TITLE
Session config: use HTTP client provided

### DIFF
--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -2,6 +2,7 @@ package awsds
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -9,7 +10,6 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -106,7 +106,7 @@ var newEC2RoleCredentials = func(sess *session.Session) *credentials.Credentials
 
 type SessionConfig struct {
 	Settings      AWSDatasourceSettings
-	Config        backend.DataSourceInstanceSettings
+	HTTPClient    *http.Client
 	UserAgentName *string
 }
 
@@ -151,20 +151,10 @@ func (sc *SessionCache) GetSession(c SessionConfig) (*session.Session, error) {
 	}
 	sc.sessCacheLock.RUnlock()
 
-	opts, err := c.Config.HTTPClientOptions()
-	if err != nil {
-		return nil, err
-	}
-
-	client, err := httpclient.New(opts)
-	if err != nil {
-		return nil, err
-	}
-
 	cfgs := []*aws.Config{
 		{
 			CredentialsChainVerboseErrors: aws.Bool(true),
-			HTTPClient:                    client,
+			HTTPClient:                    c.HTTPClient,
 		},
 	}
 

--- a/pkg/awsds/sessions_test.go
+++ b/pkg/awsds/sessions_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -249,11 +248,9 @@ func TestWithCustomHTTPClient(t *testing.T) {
 	os.Setenv(AssumeRoleEnabledEnvVarKeyName, "false")
 	cache := NewSessionCache()
 	sess, err := cache.GetSession(SessionConfig{
-		Config: backend.DataSourceInstanceSettings{
-			JSONData: []byte(`{"timeout":123}`),
-		},
+		HTTPClient: &http.Client{Timeout: 123},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, sess)
-	assert.Equal(t, time.Duration(123*time.Second), sess.Config.HTTPClient.Timeout)
+	assert.Equal(t, time.Duration(123), sess.Config.HTTPClient.Timeout)
 }


### PR DESCRIPTION
Rather than using the HTTP config and create a client, use the given client.

(This feature is not in use yet).