### PR TITLE
Fix session creation when assuming a role in us-gov regions

### DIFF
--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -110,6 +110,19 @@ type SessionConfig struct {
 	UserAgentName *string
 }
 
+func isOptInRegion(region string) bool {
+	// Opt-in region from https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
+	regions := map[string]bool{
+		"af-south-1":     true,
+		"ap-east-1":      true,
+		"ap-southeast-3": true,
+		"eu-south-1":     true,
+		"me-south-1":     true,
+		// The rest of regions will return false
+	}
+	return regions[region]
+}
+
 // GetSession returns a session from the config and possible region overrides -- implements AmazonSessionProvider
 func (sc *SessionCache) GetSession(c SessionConfig) (*session.Session, error) {
 	if c.Settings.Region == "" && c.Settings.DefaultRegion != "" {
@@ -164,7 +177,7 @@ func (sc *SessionCache) GetSession(c SessionConfig) (*session.Session, error) {
 		c.Settings.Region = ""
 	}
 	if c.Settings.Region != "" {
-		if c.Settings.AssumeRoleARN != "" && sc.authSettings.AssumeRoleEnabled {
+		if c.Settings.AssumeRoleARN != "" && sc.authSettings.AssumeRoleEnabled && isOptInRegion(c.Settings.Region) {
 			// When assuming a role, the real region is set later in a new session
 			// so we use a well-known region here (not opt-in) to obtain valid credentials
 			regionCfg = &aws.Config{Region: aws.String("us-east-1")}

--- a/pkg/awsds/sessions_test.go
+++ b/pkg/awsds/sessions_test.go
@@ -146,7 +146,7 @@ func TestNewSession_AssumeRole(t *testing.T) {
 			options ...func(*stscreds.AssumeRoleProvider)) *credentials.Credentials {
 			sess := c.(*session.Session)
 			// Verify that we are using the well-known region
-			assert.Equal(t, *sess.Config.Region, "us-east-1")
+			assert.Equal(t, "us-east-1", *sess.Config.Region)
 			return fakeNewSTSCredentials(c, roleARN, options...)
 		}
 		settings := AWSDatasourceSettings{
@@ -171,7 +171,7 @@ func TestNewSession_AssumeRole(t *testing.T) {
 			options ...func(*stscreds.AssumeRoleProvider)) *credentials.Credentials {
 			sess := c.(*session.Session)
 			// Verify that we are using the well-known region
-			assert.Equal(t, *sess.Config.Region, "us-gov-east-1")
+			assert.Equal(t, "us-gov-east-1", *sess.Config.Region)
 			return fakeNewSTSCredentials(c, roleARN, options...)
 		}
 		settings := AWSDatasourceSettings{


### PR DESCRIPTION
Issue: https://github.com/grafana/athena-datasource/issues/145

We have detected a regression caused by #49. When targeting a us-gov region, the AWS session should be created for that region, in other case, the token obtained will be invalid. More details about differences with Gov regions here: https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-differences.html

This PR hardcodes the list of opt-in regions that are available today. This has the disadvantage that at some point this list will become outdated. I tried other other possibilities:

 - Enumerating the regions using the [endpoints package](https://docs.aws.amazon.com/sdk-for-go/api/aws/endpoints/). The problem with this solution is that the list returned doesn't contain information about if a region is optional or not.
 - Using the [`DescribeRegions` of the ec2 client](https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#EC2.DescribeRegions). The problem with this is that it is hitting the AWS API, which requires a session but we need this check _before_ the session is created.