### PR TITLE
Add function to marshal errors correctly

### DIFF
--- a/pkg/sql/routes/routes.go
+++ b/pkg/sql/routes/routes.go
@@ -54,7 +54,6 @@ func marshalError(rw http.ResponseWriter, err error, code int) {
 
 func SendResources(rw http.ResponseWriter, res interface{}, err error) {
 	if err != nil {
-		rw.WriteHeader(http.StatusBadRequest)
 		marshalError(rw, err, http.StatusBadRequest)
 		return
 	}

--- a/pkg/sql/routes/routes.go
+++ b/pkg/sql/routes/routes.go
@@ -36,7 +36,6 @@ func ParseBody(body io.ReadCloser) (sqlds.Options, error) {
 }
 
 func marshalError(rw http.ResponseWriter, err error, code int) {
-	rw.WriteHeader(code)
 	errBytes, marshalErr := json.Marshal(err.Error())
 	if marshalErr != nil {
 		log.DefaultLogger.Debug(err.Error())
@@ -49,6 +48,7 @@ func marshalError(rw http.ResponseWriter, err error, code int) {
 		Write(rw, jsonErr)
 		return
 	}
+	rw.WriteHeader(code)
 	Write(rw, errBytes)
 }
 

--- a/pkg/sql/routes/routes.go
+++ b/pkg/sql/routes/routes.go
@@ -37,11 +37,15 @@ func ParseBody(body io.ReadCloser) (sqlds.Options, error) {
 
 func marshalError(rw http.ResponseWriter, err error, code int) {
 	rw.WriteHeader(code)
-	errBytes, err := json.Marshal(err.Error())
-	if err != nil {
-		log.DefaultLogger.Error(err.Error())
+	errBytes, marshalErr := json.Marshal(err.Error())
+	if marshalErr != nil {
+		log.DefaultLogger.Debug(err.Error())
 		rw.WriteHeader(http.StatusInternalServerError)
-		jsonErr, _ := json.Marshal(err)
+		jsonErr, jsonMarshalErr := json.Marshal(err)
+		if jsonMarshalErr != nil {
+			log.DefaultLogger.Error(jsonMarshalErr.Error())
+			return
+		}
 		Write(rw, jsonErr)
 		return
 	}


### PR DESCRIPTION
Forms a part of grafana/grafana#50238. 

Fixes grafana/athena-datasource#141 as an error will be correctly parsed and returned as seen in the screenshot below:
![image](https://user-images.githubusercontent.com/15019026/172176915-a2063663-429b-4fb2-9e63-045465a7795c.png)
