### PR TITLE
Include external id in session cache key

### DIFF
--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -146,7 +146,7 @@ func (sc *SessionCache) GetSession(c SessionConfig) (*session.Session, error) {
 
 	bldr := strings.Builder{}
 	for i, s := range []string{
-		c.Settings.AuthType.String(), c.Settings.AccessKey, c.Settings.Profile, c.Settings.AssumeRoleARN, c.Settings.Region, c.Settings.Endpoint,
+		c.Settings.AuthType.String(), c.Settings.AccessKey, c.Settings.Profile, c.Settings.AssumeRoleARN, c.Settings.Region, c.Settings.Endpoint, c.Settings.ExternalID,
 	} {
 		if i != 0 {
 			bldr.WriteString(":")


### PR DESCRIPTION
If external id is specified, API call from datasource with invalid external id, should fail.
https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html

Currently, Grafana doesn't include external id in cache key.
It may cause issue.

If Grafana has two datasource settings.
- datasource A with valid external ID
- datasource B with invalid external ID

Grafana will create one session cache from these two datasource setting.
If Grafana cache datasource A, API call which using datasource B will success (it should fail).

I suggest to include external id in cache key.