### PR TITLE
Chore: Allow logger to be overridden

### DIFF
--- a/pkg/sigv4/sigv4.go
+++ b/pkg/sigv4/sigv4.go
@@ -28,7 +28,6 @@ import (
 
 var (
 	signerCache sync.Map
-	plog        = backend.Logger
 )
 
 type middleware struct {
@@ -208,7 +207,7 @@ func createSigner(cfg *Config, verboseMode bool) (*v4.Signer, error) {
 
 	var signerOpts = func(s *v4.Signer) {
 		if verboseMode {
-			s.Logger = awsLoggerAdapter{logger: plog}
+			s.Logger = awsLoggerAdapter{logger: backend.Logger}
 			s.Debug = aws.LogDebugWithSigning
 		}
 	}
@@ -306,9 +305,9 @@ func (m *middleware) logRequest(req *http.Request, args ...interface{}) {
 	}
 	dump, err := httputil.DumpRequest(req, true)
 	if err != nil {
-		plog.Error("Unable to dump request", "err", err)
+		backend.Logger.Error("Unable to dump request", "err", err)
 	}
-	plog.Debug("Request dump", append([]interface{}{"dump", string(dump)}, args...)...)
+	backend.Logger.Debug("Request dump", append([]interface{}{"dump", string(dump)}, args...)...)
 }
 
 type awsLoggerAdapter struct {

--- a/pkg/sigv4/sigv4_test.go
+++ b/pkg/sigv4/sigv4_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -141,13 +142,13 @@ func TestNew(t *testing.T) {
 		cfg := &Config{AuthType: "ec2_iam_role"}
 
 		// Mock logger
-		origLogger := plog
+		origLogger := backend.Logger
 		t.Cleanup(func() {
-			plog = origLogger
+			backend.Logger = origLogger
 		})
 
 		fakeLogger := &fakeLogger{}
-		plog = fakeLogger
+		backend.Logger = fakeLogger
 
 		rt, err := New(cfg, &fakeTransport{}, Opts{VerboseMode: true})
 		require.NoError(t, err)
@@ -173,13 +174,13 @@ func TestNew(t *testing.T) {
 		cfg := &Config{AuthType: "ec2_iam_role"}
 
 		// Mock logger
-		origLogger := plog
+		origLogger := backend.Logger
 		t.Cleanup(func() {
-			plog = origLogger
+			backend.Logger = origLogger
 		})
 
 		fakeLogger := &fakeLogger{}
-		plog = fakeLogger
+		backend.Logger = fakeLogger
 
 		rt, err := New(cfg, &fakeTransport{}, Opts{VerboseMode: false})
 		require.NoError(t, err)


### PR DESCRIPTION
By assigning `backend.Logger` to a variable it makes it impossible to override the logger implementation when grafana-aws-sdk is used in Grafana itself for the core CloudWatch datasource. This removes the assignment of `backend.Logger` to a variable.