### PR TITLE
Custom session duration

### DIFF
--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -48,7 +48,7 @@ const AllowedAuthProvidersEnvVarKeyName = "AWS_AUTH_AllowedAuthProviders"
 const AssumeRoleEnabledEnvVarKeyName = "AWS_AUTH_AssumeRoleEnabled"
 
 // SessionDurationEnvVarKeyName is the string literal for the session duration variable key name
-const SessionDurationEnvVarKeyName = "AWS_SESSION_DURATION"
+const SessionDurationEnvVarKeyName = "AWS_AUTH_SESSION_DURATION"
 
 func ReadAuthSettingsFromEnvironmentVariables() *AuthSettings {
 	authSettings := &AuthSettings{}

--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -57,7 +57,7 @@ func ReadAuthSettingsFromEnvironmentVariables() *AuthSettings {
 	for _, authProvider := range strings.Split(providers, ",") {
 		authProvider = strings.TrimSpace(authProvider)
 		if authProvider != "" {
-			allowedAuthProviders = append(authSettings.AllowedAuthProviders, authProvider)
+			allowedAuthProviders = append(allowedAuthProviders, authProvider)
 		}
 	}
 

--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -84,7 +84,7 @@ func ReadAuthSettingsFromEnvironmentVariables() *AuthSettings {
 	if sessionDurationString != "" {
 		sessionDuration, err := gtime.ParseDuration(sessionDurationString)
 		if err != nil {
-			backend.Logger.Error(fmt.Sprintf("could not parse '%s'", SessionDurationEnvVarKeyName), err)
+			backend.Logger.Error("could not parse env variable", "var", SessionDurationEnvVarKeyName)
 		} else {
 			authSettings.SessionDuration = &sessionDuration
 		}

--- a/pkg/awsds/types.go
+++ b/pkg/awsds/types.go
@@ -1,6 +1,8 @@
 package awsds
 
 import (
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
@@ -11,4 +13,5 @@ type AmazonSessionProvider func(region string, s AWSDatasourceSettings) (*sessio
 type AuthSettings struct {
 	AllowedAuthProviders []string
 	AssumeRoleEnabled    bool
+	SessionDuration      *time.Duration
 }


### PR DESCRIPTION
A customer has reported that they're getting SignatureDoesNotMatch errors while running multiple CloudWatch logs queries in parallel. They're using `AWS SDK Default` auth and they're assuming a role. We have not been able to repro this issue, but the theory is that the logs query is started using temporary STS credentials that lasts for 15 minutes. The query then runs for more than 15 minutes, so once it's completed different credentials are being used compared to when the query started. 

Once this is released, the customer will be able to test this by setting the new environment variable `AWS_SESSION_DURATION` to a duration longer than the default value (currently 15 minutes in STS). 

~~This PR is still in draft mode because we're waiting for approval from the customer to help us test this in future 9.0 patch release.~~

The customer has confirmed that they're willing to help us test this. https://github.com/grafana/support-escalations/issues/2642