### PR TITLE
Switch ec2 role cred provider to remote cred provider

### DIFF
--- a/pkg/awsds/sessions_test.go
+++ b/pkg/awsds/sessions_test.go
@@ -265,7 +265,7 @@ func TestNewSession_EC2IAMRole(t *testing.T) {
 	newEC2Metadata = func(p client.ConfigProvider, cfgs ...*aws.Config) *ec2metadata.EC2Metadata {
 		return nil
 	}
-	newEC2RoleCredentials = func(sess *session.Session) *credentials.Credentials {
+	newRemoteCredentials = func(sess *session.Session) *credentials.Credentials {
 		return credentials.NewCredentials(&ec2rolecreds.EC2RoleProvider{Client: newEC2Metadata(nil), ExpiryWindow: stscreds.DefaultDuration})
 	}
 

--- a/pkg/sigv4/sigv4.go
+++ b/pkg/sigv4/sigv4.go
@@ -16,9 +16,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
-	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/aws/session"
 	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
 	"github.com/aws/aws-sdk-go/private/protocol/rest"
@@ -225,7 +224,7 @@ func createSigner(cfg *Config, verboseMode bool) (*v4.Signer, error) {
 		if err != nil {
 			return nil, err
 		}
-		c = credentials.NewCredentials(&ec2rolecreds.EC2RoleProvider{Client: ec2metadata.New(s), ExpiryWindow: stscreds.DefaultDuration})
+		c = credentials.NewCredentials(defaults.RemoteCredProvider(*s.Config, s.Handlers))
 
 		if cfg.AssumeRoleARN != "" {
 			s, err = session.NewSession(&aws.Config{


### PR DESCRIPTION
This PR updates the Workspace IAM Role provider to pull credentials from both EC2 IAM Roles and ECS Task IAM Roles