### PR TITLE
Add grafana partnerships to codeowners for sigv4

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Grafana Partnerships Team
+/pkg/sigv4 @grafana/grafana-partnerships-team


### PR DESCRIPTION
Adding sigv4 middleware to point towards https://github.com/orgs/grafana/teams/grafana-partnerships-team (part of handover process)

Related PR https://github.com/grafana/grafana/pull/55355