### PR TITLE
Updating opt-in regions list

### DIFF
--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -128,8 +128,12 @@ func isOptInRegion(region string) bool {
 	regions := map[string]bool{
 		"af-south-1":     true,
 		"ap-east-1":      true,
+		"ap-south-2":     true,
 		"ap-southeast-3": true,
+		"eu-central-2":   true,
 		"eu-south-1":     true,
+		"eu-south-2":     true,
+		"me-central-1":   true,
 		"me-south-1":     true,
 		// The rest of regions will return false
 	}


### PR DESCRIPTION
The sessions.go file hard-codes the list of AWS opt-in regions. This list is out of date and impacts users ability to use new opt in regions.