### PR TITLE
Pass query args to GetAsyncDB

### DIFF
--- a/pkg/awsds/asyncDatasource.go
+++ b/pkg/awsds/asyncDatasource.go
@@ -115,8 +115,9 @@ func (ds *AsyncAWSDatasource) handleAsyncQuery(ctx context.Context, req backend.
 		fillMode = q.FillMissing
 	}
 
+	asyncDB, _ := ds.driver.GetAsyncDB(ds.connSettings, q.ConnectionArgs)
 	if q.QueryID == "" {
-		queryID, err := startQuery(ctx, ds.asyncDB, q)
+		queryID, err := startQuery(ctx, asyncDB, q)
 		if err != nil {
 			return getErrorFrameFromQuery(q), err
 		}
@@ -128,7 +129,7 @@ func (ds *AsyncAWSDatasource) handleAsyncQuery(ctx context.Context, req backend.
 		}, nil
 	}
 
-	status, err := queryStatus(ctx, ds.asyncDB, q)
+	status, err := queryStatus(ctx, asyncDB, q)
 	if err != nil {
 		return getErrorFrameFromQuery(q), err
 	}


### PR DESCRIPTION
Work for Athena query result reuse work.

This passes the ConnectionArgs to the Datasource's `GetAsyncDB` method. The `ConnectionArgs` are specific to a query. Currently, synchronous queries already get the connection args (this is handled in sqlds https://github.com/grafana/sqlds/blob/f35c5a62f66c02aef63b260c1e0a25568ae698b6/datasource.go#L169).