### PR TITLE
Fix connections for multiple async datasources

### DIFF
--- a/pkg/awsds/asyncDatasource_test.go
+++ b/pkg/awsds/asyncDatasource_test.go
@@ -1,0 +1,105 @@
+package awsds
+
+import (
+	"context"
+	"database/sql/driver"
+	"encoding/json"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/sqlds/v2"
+)
+
+type fakeAsyncDB struct{}
+
+func (fakeAsyncDB) Begin() (driver.Tx, error)                                        { return nil, nil }
+func (fakeAsyncDB) Prepare(query string) (driver.Stmt, error)                        { return nil, nil }
+func (fakeAsyncDB) Close() error                                                     { return nil }
+func (fakeAsyncDB) Ping(ctx context.Context) error                                   { return nil }
+func (fakeAsyncDB) CancelQuery(ctx context.Context, queryID string) error            { return nil }
+func (fakeAsyncDB) GetRows(ctx context.Context, queryID string) (driver.Rows, error) { return nil, nil }
+
+func (fakeAsyncDB) GetQueryID(ctx context.Context, query string, args ...interface{}) (bool, string, error) {
+	return false, "", nil
+}
+
+func (fakeAsyncDB) QueryStatus(ctx context.Context, queryID string) (QueryStatus, error) {
+	return QueryUnknown, nil
+}
+
+func (fakeAsyncDB) StartQuery(ctx context.Context, query string, args ...interface{}) (string, error) {
+	return "", nil
+}
+
+type fakeDriver struct {
+	openDBfn func() (AsyncDB, error)
+	AsyncDriver
+}
+
+func (d fakeDriver) GetAsyncDB(backend.DataSourceInstanceSettings, json.RawMessage) (db AsyncDB, err error) {
+	return d.openDBfn()
+}
+
+func Test_getDBConnectionFromQuery(t *testing.T) {
+	db := &fakeAsyncDB{}
+	db2 := &fakeAsyncDB{}
+	db3 := &fakeAsyncDB{}
+	d := &fakeDriver{openDBfn: func() (AsyncDB, error) { return db3, nil }}
+	tests := []struct {
+		desc        string
+		dsUID       string
+		args        string
+		existingDB  AsyncDB
+		expectedKey string
+		expectedDB  AsyncDB
+	}{
+		{
+			desc:        "it should return the default db with no args",
+			dsUID:       "uid1",
+			args:        "",
+			expectedKey: "uid1-default",
+			expectedDB:  db,
+		},
+		{
+			desc:        "it should return the cached connection for the given args",
+			dsUID:       "uid1",
+			args:        "foo",
+			expectedKey: "uid1-foo",
+			existingDB:  db2,
+			expectedDB:  db2,
+		},
+		{
+			desc:        "it should create a new connection with the given args",
+			dsUID:       "uid1",
+			args:        "foo",
+			expectedKey: "uid1-foo",
+			expectedDB:  db3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			ds := &AsyncAWSDatasource{driver: d, SQLDatasource: &sqlds.SQLDatasource{EnableMultipleConnections: true}}
+			settings := backend.DataSourceInstanceSettings{UID: tt.dsUID}
+			key := defaultKey(tt.dsUID)
+			// Add the mandatory default db
+			ds.storeDBConnection(key, dbConnection{db, settings})
+			if tt.args != "" {
+				key = keyWithConnectionArgs(tt.dsUID, []byte(tt.args))
+			}
+			if tt.existingDB != nil {
+				ds.storeDBConnection(key, dbConnection{tt.existingDB, settings})
+			}
+
+			dbConn, err := ds.getAsyncDBFromQuery(&AsyncQuery{Query: sqlds.Query{ConnectionArgs: json.RawMessage(tt.args)}}, tt.dsUID)
+			if err != nil {
+				t.Fatalf("unexpected error %v", err)
+			}
+			if key != tt.expectedKey {
+				t.Fatalf("unexpected cache key %s", key)
+			}
+			if dbConn != tt.expectedDB {
+				t.Fatalf("unexpected result %v", dbConn)
+			}
+		})
+	}
+}


### PR DESCRIPTION
As described in the linked issue, the way that AsyncAWSDatasource is currently set up it overwrites the AsyncDB field with the most recently added Async data source. This changes it to a map, so that multiple async datasources can exist concurrently

Fixes #72 