### PR TITLE
Add new region to opt-region list

### DIFF
--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -130,6 +130,7 @@ func isOptInRegion(region string) bool {
 		"ap-east-1":      true,
 		"ap-south-2":     true,
 		"ap-southeast-3": true,
+		"ap-southeast-4": true,
 		"eu-central-2":   true,
 		"eu-south-1":     true,
 		"eu-south-2":     true,


### PR DESCRIPTION
The sessions.go file hard-codes the list of AWS opt-in regions. This list is out of date and impacts users ability to use new opt in regions.

Issue: https://github.com/grafana/grafana-aws-sdk/issues/79