### PR TITLE
Async queries should support expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.15.1
+
+- Fix expressions with async datasource @iwysiu in [#83](https://github.com/grafana/grafana-aws-sdk/pull/83)
+
 ## v0.15.0
 
 Updating opt-in regions list by @eunice98k in https://github.com/grafana/grafana-aws-sdk/pull/80

--- a/pkg/awsds/asyncDatasource.go
+++ b/pkg/awsds/asyncDatasource.go
@@ -97,7 +97,8 @@ func (ds *AsyncAWSDatasource) QueryData(ctx context.Context, req *backend.QueryD
 	}
 
 	_, isFromAlert := req.Headers["FromAlert"]
-	if syncExectionEnabled || isFromAlert {
+	_, isFromExpression := req.Headers["http_X-Grafana-From-Expr"]
+	if syncExectionEnabled || isFromAlert || isFromExpression {
 		return ds.sqldsQueryDataHander.QueryData(ctx, req)
 	}
 

--- a/pkg/awsds/asyncDatasource.go
+++ b/pkg/awsds/asyncDatasource.go
@@ -16,6 +16,8 @@ import (
 )
 
 const defaultKeySuffix = "default"
+const fromAlertHeader = "FromAlert"
+const fromExpressionHeader = "http_X-Grafana-From-Expr"
 
 func defaultKey(datasourceUID string) string {
 	return fmt.Sprintf("%s-%s", datasourceUID, defaultKeySuffix)
@@ -96,8 +98,8 @@ func (ds *AsyncAWSDatasource) QueryData(ctx context.Context, req *backend.QueryD
 		}
 	}
 
-	_, isFromAlert := req.Headers["FromAlert"]
-	_, isFromExpression := req.Headers["http_X-Grafana-From-Expr"]
+	_, isFromAlert := req.Headers[fromAlertHeader]
+	_, isFromExpression := req.Headers[fromExpressionHeader]
 	if syncExectionEnabled || isFromAlert || isFromExpression {
 		return ds.sqldsQueryDataHander.QueryData(ctx, req)
 	}

--- a/pkg/awsds/asyncDatasource_test.go
+++ b/pkg/awsds/asyncDatasource_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/sqlds/v2"
+	"github.com/stretchr/testify/assert"
 )
 
 type fakeAsyncDB struct{}
@@ -100,6 +101,44 @@ func Test_getDBConnectionFromQuery(t *testing.T) {
 			if dbConn != tt.expectedDB {
 				t.Fatalf("unexpected result %v", dbConn)
 			}
+		})
+	}
+}
+
+func TestAsyncQueryData(t *testing.T) {
+	tests := []struct {
+		desc    string
+		headers map[string]string
+		called  bool
+	}{
+		{
+			"assert header",
+			map[string]string{fromAlertHeader: "some value"},
+			true,
+		},
+		{
+			"expression Header",
+			map[string]string{fromExpressionHeader: "some value"},
+			true,
+		},
+		{
+			"no header",
+			map[string]string{},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			syncCalled := false
+			mockQueryData := func(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+				syncCalled = true
+				return nil, nil
+			}
+			ds := &AsyncAWSDatasource{sqldsQueryDataHander: mockQueryData}
+
+			_, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{Headers: tt.headers})
+			assert.NoError(t, err)
+			assert.Equal(t, syncCalled, tt.called)
 		})
 	}
 }

--- a/pkg/awsds/asyncDatasource_test.go
+++ b/pkg/awsds/asyncDatasource_test.go
@@ -105,26 +105,18 @@ func Test_getDBConnectionFromQuery(t *testing.T) {
 	}
 }
 
-func TestAsyncQueryData(t *testing.T) {
+func Test_Async_QueryData_uses_synchronous_flow_when_header_has_alert_and_expression(t *testing.T) {
 	tests := []struct {
 		desc    string
 		headers map[string]string
-		called  bool
 	}{
 		{
-			"assert header",
+			"alert header",
 			map[string]string{fromAlertHeader: "some value"},
-			true,
 		},
 		{
 			"expression Header",
 			map[string]string{fromExpressionHeader: "some value"},
-			true,
-		},
-		{
-			"no header",
-			map[string]string{},
-			false,
 		},
 	}
 	for _, tt := range tests {
@@ -138,7 +130,7 @@ func TestAsyncQueryData(t *testing.T) {
 
 			_, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{Headers: tt.headers})
 			assert.NoError(t, err)
-			assert.Equal(t, syncCalled, tt.called)
+			assert.True(t, syncCalled)
 		})
 	}
 }


### PR DESCRIPTION
Updates the AsyncDatasource.QueryData to check for expressions using the header introduced in: https://github.com/grafana/grafana/pull/65306/files . I also added it to the changelog because I imagine that we want to release this bug fix after it goes in.

part of #75 