### PR TITLE
Add Support for Temporary Credentials in Grafana Cloud

### DIFF
--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -106,6 +106,7 @@ func ReadAuthSettingsFromEnvironmentVariables() *AuthSettings {
 
 // Session factory.
 // Stubbable by tests.
+//
 //nolint:gocritic
 var newSession = func(cfgs ...*aws.Config) (*session.Session, error) {
 	return session.NewSession(cfgs...)
@@ -113,11 +114,13 @@ var newSession = func(cfgs ...*aws.Config) (*session.Session, error) {
 
 // STS credentials factory.
 // Stubbable by tests.
+//
 //nolint:gocritic
 var newSTSCredentials = stscreds.NewCredentials
 
 // EC2Metadata service factory.
 // Stubbable by tests.
+//
 //nolint:gocritic
 var newEC2Metadata = ec2metadata.New
 
@@ -267,7 +270,7 @@ func (sc *SessionCache) GetSession(c SessionConfig) (*session.Session, error) {
 	expiration := time.Now().UTC().Add(duration)
 	if c.Settings.AssumeRoleARN != "" && sc.authSettings.AssumeRoleEnabled {
 		// We should assume a role in AWS
-		backend.Logger.Info("Trying to assume role in AWS", "arn", c.Settings.AssumeRoleARN)
+		backend.Logger.Debug("Trying to assume role in AWS", "arn", c.Settings.AssumeRoleARN)
 
 		cfgs := []*aws.Config{
 			{

--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -58,6 +58,9 @@ const AssumeRoleEnabledEnvVarKeyName = "AWS_AUTH_AssumeRoleEnabled"
 // SessionDurationEnvVarKeyName is the string literal for the session duration variable key name
 const SessionDurationEnvVarKeyName = "AWS_AUTH_SESSION_DURATION"
 
+// GrafanaAssumeRoleExternalIdKeyName is the string literal for the grafana assume role external id environment variable key name
+const GrafanaAssumeRoleExternalIdKeyName = "AWS_AUTH_EXTERNAL_ID"
+
 func ReadAuthSettingsFromEnvironmentVariables() *AuthSettings {
 	authSettings := &AuthSettings{}
 	allowedAuthProviders := []string{}
@@ -161,6 +164,7 @@ func (sc *SessionCache) GetSession(c SessionConfig) (*session.Session, error) {
 			break
 		}
 	}
+
 	if !authTypeAllowed {
 		return nil, fmt.Errorf("attempting to use an auth type that is not allowed: %q", c.Settings.AuthType.String())
 	}
@@ -276,8 +280,7 @@ func (sc *SessionCache) GetSession(c SessionConfig) (*session.Session, error) {
 					p.Expiry.SetExpiration(expiration, 0)
 					p.Duration = duration
 					if c.Settings.AuthType == AuthTypeGrafanaAssumeRole {
-						// TODO: pull externalid from somewhere, can not be user input or hardcoded string
-						p.ExternalID = aws.String("grafanamagic")
+						p.ExternalID = aws.String(os.Getenv(GrafanaAssumeRoleExternalIdKeyName))
 					} else if c.Settings.ExternalID != "" {
 						p.ExternalID = aws.String(c.Settings.ExternalID)
 					}

--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -96,6 +96,7 @@ func ReadAuthSettingsFromEnvironmentVariables() *AuthSettings {
 
 // Session factory.
 // Stubbable by tests.
+//
 //nolint:gocritic
 var newSession = func(cfgs ...*aws.Config) (*session.Session, error) {
 	return session.NewSession(cfgs...)
@@ -103,11 +104,13 @@ var newSession = func(cfgs ...*aws.Config) (*session.Session, error) {
 
 // STS credentials factory.
 // Stubbable by tests.
+//
 //nolint:gocritic
 var newSTSCredentials = stscreds.NewCredentials
 
 // EC2Metadata service factory.
 // Stubbable by tests.
+//
 //nolint:gocritic
 var newEC2Metadata = ec2metadata.New
 
@@ -162,6 +165,7 @@ func (sc *SessionCache) GetSession(c SessionConfig) (*session.Session, error) {
 		return nil, fmt.Errorf("attempting to use assume role (ARN) which is disabled in grafana.ini")
 	}
 
+	// Hash the settings to use as a cache key
 	bldr := strings.Builder{}
 	for i, s := range []string{
 		c.Settings.AuthType.String(), c.Settings.AccessKey, c.Settings.SecretKey, c.Settings.Profile, c.Settings.AssumeRoleARN, c.Settings.Region, c.Settings.Endpoint,
@@ -175,6 +179,7 @@ func (sc *SessionCache) GetSession(c SessionConfig) (*session.Session, error) {
 	hashedSettings := sha256.Sum256([]byte(bldr.String()))
 	cacheKey := fmt.Sprintf("%v", hashedSettings)
 
+	// Check if we have a valid session in the cache, if so return it
 	sc.sessCacheLock.RLock()
 	if env, ok := sc.sessCache[cacheKey]; ok {
 		if env.expiration.After(time.Now().UTC()) {
@@ -229,6 +234,8 @@ func (sc *SessionCache) GetSession(c SessionConfig) (*session.Session, error) {
 			return nil, err
 		}
 		cfgs = append(cfgs, &aws.Config{Credentials: newRemoteCredentials(sess)})
+	case AuthTypeGrafanaAssumeRole:
+		backend.Logger.Debug("Authenticating towards AWS with Grafana Assume Role", "region", c.Settings.Region)
 	default:
 		panic(fmt.Sprintf("Unrecognized authType: %d", c.Settings.AuthType))
 	}
@@ -249,7 +256,7 @@ func (sc *SessionCache) GetSession(c SessionConfig) (*session.Session, error) {
 	expiration := time.Now().UTC().Add(duration)
 	if c.Settings.AssumeRoleARN != "" && sc.authSettings.AssumeRoleEnabled {
 		// We should assume a role in AWS
-		backend.Logger.Debug("Trying to assume role in AWS", "arn", c.Settings.AssumeRoleARN)
+		backend.Logger.Info("Trying to assume role in AWS", "arn", c.Settings.AssumeRoleARN)
 
 		cfgs := []*aws.Config{
 			{
@@ -261,7 +268,10 @@ func (sc *SessionCache) GetSession(c SessionConfig) (*session.Session, error) {
 					// Not sure if this is necessary, overlaps with p.Duration and is undocumented
 					p.Expiry.SetExpiration(expiration, 0)
 					p.Duration = duration
-					if c.Settings.ExternalID != "" {
+					if c.Settings.AuthType == AuthTypeGrafanaAssumeRole {
+						// TODO: pull externalid from somewhere, can not be user input or hardcoded string
+						p.ExternalID = aws.String("grafanamagic")
+					} else if c.Settings.ExternalID != "" {
 						p.ExternalID = aws.String(c.Settings.ExternalID)
 					}
 				}),

--- a/pkg/awsds/sessions_test.go
+++ b/pkg/awsds/sessions_test.go
@@ -265,6 +265,8 @@ func TestNewSession_GrafanaAssumeRole(t *testing.T) {
 	})
 
 	t.Run("externalID is passed to the session", func(t *testing.T) {
+		originalExternalId := os.Getenv(GrafanaAssumeRoleExternalIdKeyName)
+		os.Setenv(GrafanaAssumeRoleExternalIdKeyName, "pretendExternalId")
 		newSTSCredentials = func(c client.ConfigProvider, roleARN string,
 			options ...func(*stscreds.AssumeRoleProvider)) *credentials.Credentials {
 			p := &stscreds.AssumeRoleProvider{
@@ -275,7 +277,7 @@ func TestNewSession_GrafanaAssumeRole(t *testing.T) {
 			}
 			require.NotNil(t, p.ExternalID)
 
-			assert.Equal(t, "grafanamagic", *p.ExternalID)
+			assert.Equal(t, "pretendExternalId", *p.ExternalID)
 			return credentials.NewCredentials(p)
 		}
 
@@ -289,6 +291,7 @@ func TestNewSession_GrafanaAssumeRole(t *testing.T) {
 		}})
 
 		require.NoError(t, err)
+		os.Setenv(GrafanaAssumeRoleExternalIdKeyName, originalExternalId)
 	})
 
 	t.Run("roleARN is passed to the session", func(t *testing.T) {
@@ -303,16 +306,16 @@ func TestNewSession_GrafanaAssumeRole(t *testing.T) {
 			require.Equal(t, "test_arn", roleARN)
 			return credentials.NewCredentials(p)
 		}
-	
+
 		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "grafana_assume_role"))
 		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
-	
+
 		cache := NewSessionCache()
 		_, err := cache.GetSession(SessionConfig{Settings: AWSDatasourceSettings{
 			AuthType:      AuthTypeGrafanaAssumeRole,
 			AssumeRoleARN: "test_arn",
 		}})
-	
+
 		require.NoError(t, err)
 	})
 }

--- a/pkg/awsds/sessions_test.go
+++ b/pkg/awsds/sessions_test.go
@@ -61,8 +61,8 @@ func TestNewSession_AssumeRole(t *testing.T) {
 		settings := AWSDatasourceSettings{
 			AssumeRoleARN: roleARN,
 		}
-		os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default")
-		os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true")
+		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
+		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
 		cache := NewSessionCache()
 		sess, err := cache.GetSession(SessionConfig{Settings: settings})
 		require.NoError(t, err)
@@ -85,8 +85,8 @@ func TestNewSession_AssumeRole(t *testing.T) {
 			AssumeRoleARN: roleARN,
 			ExternalID:    externalID,
 		}
-		os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default")
-		os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true")
+		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
+		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
 		cache := NewSessionCache()
 		sess, err := cache.GetSession(SessionConfig{Settings: settings})
 		require.NoError(t, err)
@@ -108,9 +108,9 @@ func TestNewSession_AssumeRole(t *testing.T) {
 		settings := AWSDatasourceSettings{
 			AssumeRoleARN: roleARN,
 		}
-		os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default")
-		os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true")
-		os.Setenv(SessionDurationEnvVarKeyName, "20m")
+		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
+		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
+		require.NoError(t, os.Setenv(SessionDurationEnvVarKeyName, "20m"))
 		cache := NewSessionCache()
 		sess, err := cache.GetSession(SessionConfig{Settings: settings})
 		require.NoError(t, err)
@@ -131,8 +131,8 @@ func TestNewSession_AssumeRole(t *testing.T) {
 		settings := AWSDatasourceSettings{
 			AssumeRoleARN: roleARN,
 		}
-		os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default")
-		os.Setenv(AssumeRoleEnabledEnvVarKeyName, "false")
+		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
+		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "false"))
 		cache := NewSessionCache()
 		sess, err := cache.GetSession(SessionConfig{Settings: settings})
 		require.Error(t, err)
@@ -147,7 +147,7 @@ func TestNewSession_AssumeRole(t *testing.T) {
 		settings := AWSDatasourceSettings{
 			AssumeRoleARN: roleARN,
 		}
-		os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default")
+		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
 		cache := NewSessionCache()
 		sess, err := cache.GetSession(SessionConfig{Settings: settings})
 		require.NoError(t, err)
@@ -176,8 +176,8 @@ func TestNewSession_AssumeRole(t *testing.T) {
 			AssumeRoleARN: "test",
 			Region:        "me-south-1",
 		}
-		os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default")
-		os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true")
+		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
+		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
 		cache := NewSessionCache()
 		sess, err := cache.GetSession(SessionConfig{Settings: settings})
 		newSTSCredentials = fakeNewSTSCredentials
@@ -201,8 +201,8 @@ func TestNewSession_AssumeRole(t *testing.T) {
 			AssumeRoleARN: "test",
 			Region:        "us-gov-east-1",
 		}
-		os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default")
-		os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true")
+		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
+		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
 		cache := NewSessionCache()
 		sess, err := cache.GetSession(SessionConfig{Settings: settings})
 		newSTSCredentials = fakeNewSTSCredentials
@@ -219,7 +219,7 @@ func TestNewSession_AllowedAuthProviders(t *testing.T) {
 		settings := AWSDatasourceSettings{
 			AuthType: AuthTypeDefault,
 		}
-		os.Setenv(AllowedAuthProvidersEnvVarKeyName, "keys")
+		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "keys"))
 		cache := NewSessionCache()
 		sess, err := cache.GetSession(SessionConfig{Settings: settings})
 		require.Error(t, err)
@@ -232,7 +232,7 @@ func TestNewSession_AllowedAuthProviders(t *testing.T) {
 		settings := AWSDatasourceSettings{
 			AuthType: AuthTypeKeys,
 		}
-		os.Setenv(AllowedAuthProvidersEnvVarKeyName, "keys")
+		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "keys"))
 		cache := NewSessionCache()
 		sess, err := cache.GetSession(SessionConfig{Settings: settings})
 		require.NoError(t, err)
@@ -251,6 +251,69 @@ func TestNewSession_AllowedAuthProviders(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, sess)
 		}
+	})
+}
+
+func TestNewSession_GrafanaAssumeRole(t *testing.T) {
+	origAllowedAuthProvidersEnvVarKeyName := os.Getenv(AllowedAuthProvidersEnvVarKeyName)
+	origAssumeRoleEnabledEnvVarKeyName := os.Getenv(AssumeRoleEnabledEnvVarKeyName)
+	origNewSTSCredentials := newSTSCredentials
+	t.Cleanup(func() {
+		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, origAllowedAuthProvidersEnvVarKeyName))
+		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, origAssumeRoleEnabledEnvVarKeyName))
+		newSTSCredentials = origNewSTSCredentials
+	})
+
+	t.Run("externalID is passed to the session", func(t *testing.T) {
+		newSTSCredentials = func(c client.ConfigProvider, roleARN string,
+			options ...func(*stscreds.AssumeRoleProvider)) *credentials.Credentials {
+			p := &stscreds.AssumeRoleProvider{
+				RoleARN: roleARN,
+			}
+			for _, o := range options {
+				o(p)
+			}
+			require.NotNil(t, p.ExternalID)
+
+			assert.Equal(t, "grafanamagic", *p.ExternalID)
+			return credentials.NewCredentials(p)
+		}
+
+		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "grafana_assume_role"))
+		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
+
+		cache := NewSessionCache()
+		_, err := cache.GetSession(SessionConfig{Settings: AWSDatasourceSettings{
+			AuthType:      AuthTypeGrafanaAssumeRole,
+			AssumeRoleARN: "test_arn",
+		}})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("roleARN is passed to the session", func(t *testing.T) {
+		newSTSCredentials = func(c client.ConfigProvider, roleARN string,
+			options ...func(*stscreds.AssumeRoleProvider)) *credentials.Credentials {
+			p := &stscreds.AssumeRoleProvider{
+				RoleARN: roleARN,
+			}
+			for _, o := range options {
+				o(p)
+			}
+			require.Equal(t, "test_arn", roleARN)
+			return credentials.NewCredentials(p)
+		}
+	
+		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "grafana_assume_role"))
+		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
+	
+		cache := NewSessionCache()
+		_, err := cache.GetSession(SessionConfig{Settings: AWSDatasourceSettings{
+			AuthType:      AuthTypeGrafanaAssumeRole,
+			AssumeRoleARN: "test_arn",
+		}})
+	
+		require.NoError(t, err)
 	})
 }
 
@@ -284,8 +347,8 @@ func TestNewSession_EC2IAMRole(t *testing.T) {
 			Endpoint: "foo",
 		}
 
-		os.Setenv(AllowedAuthProvidersEnvVarKeyName, "ec2_iam_role")
-		os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true")
+		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "ec2_iam_role"))
+		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
 
 		cache := NewSessionCache()
 		sess, err := cache.GetSession(SessionConfig{Settings: settings})
@@ -317,8 +380,8 @@ func unsetEnvironmentVariables() {
 
 func TestWithUserAgent(t *testing.T) {
 	defer unsetEnvironmentVariables()
-	os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default")
-	os.Setenv(AssumeRoleEnabledEnvVarKeyName, "false")
+	require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
+	require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "false"))
 	cache := NewSessionCache()
 	sess, err := cache.GetSession(SessionConfig{UserAgentName: aws.String("Athena")})
 	require.NoError(t, err)
@@ -334,8 +397,8 @@ func TestWithUserAgent(t *testing.T) {
 
 func TestWithCustomHTTPClient(t *testing.T) {
 	defer unsetEnvironmentVariables()
-	os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default")
-	os.Setenv(AssumeRoleEnabledEnvVarKeyName, "false")
+	require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
+	require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "false"))
 	cache := NewSessionCache()
 	sess, err := cache.GetSession(SessionConfig{
 		HTTPClient: &http.Client{Timeout: 123},

--- a/pkg/awsds/settings.go
+++ b/pkg/awsds/settings.go
@@ -17,6 +17,7 @@ const (
 	AuthTypeSharedCreds
 	AuthTypeKeys
 	AuthTypeEC2IAMRole
+	AuthTypeGrafanaAssumeRole //cloud only
 )
 
 func (at AuthType) String() string {
@@ -29,6 +30,8 @@ func (at AuthType) String() string {
 		return "keys"
 	case AuthTypeEC2IAMRole:
 		return "ec2_iam_role"
+	case AuthTypeGrafanaAssumeRole:
+		return "grafana_assume_role"
 	default:
 		panic(fmt.Sprintf("Unrecognized auth type %d", at))
 	}
@@ -46,6 +49,8 @@ func ToAuthType(authType string) (AuthType, error) {
 		return AuthTypeEC2IAMRole, nil
 	case "arn":
 		return AuthTypeDefault, nil
+	case "grafana_assume_role":
+		return AuthTypeGrafanaAssumeRole, nil
 	default:
 		return AuthTypeDefault, fmt.Errorf("invalid auth type: %s", authType)
 	}
@@ -75,6 +80,8 @@ func (at *AuthType) UnmarshalJSON(b []byte) error {
 		*at = AuthTypeKeys
 	case "ec2_iam_role":
 		*at = AuthTypeEC2IAMRole
+	case "grafana_assume_role":
+		*at = AuthTypeGrafanaAssumeRole
 	case "default":
 		fallthrough
 	default:


### PR DESCRIPTION
Adding support for experimental/beta feature to allow the use of AWS Temporary Credentials in Grafana Cloud. 

To test locally : 
- in main grafana enable the feature toggle `awsDatasourcesTempCredentials`
- npm link to the latest version of main of https://github.com/grafana/grafana-aws-sdk-react (assuming it hasn't been published yet)
- pull these changes locally in your version of grafana-aws-sdk
- add a line to go.mod in main grafana to connect to your local version of the sdk like so `replace github.com/grafana/grafana-aws-sd => /Users/yourfilepathtothegrafana-aws-sdk`
- add a long term aws user's access key and secret key to a .aws/credentials file under the profile name `[assume_role_credentials]` (sarah or ida can point you to an existing one if you need)
- make sure that user has sts permissions
- create a role (not user!) in aws with the required cloudwatch permissions. Create a trust relationship with the AWS account that has the long term credentials. Choose an externalId. (Alternatively if you want to use one Sarah and Ida have been using we can point you to it)
- Set that externalId in the custom.ini 

You should now be able to auth with the new GrafanaAssumeRole feature. 
