### PR TITLE
ShouldCacheQuery should handle nil responses

### DIFF
--- a/pkg/awsds/utils.go
+++ b/pkg/awsds/utils.go
@@ -11,7 +11,12 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
+// ShouldCacheQuery checks whether resp contains a running query, and returns false if it does
 func ShouldCacheQuery(resp *backend.QueryDataResponse) bool {
+	if resp == nil {
+		return true
+	}
+
 	shouldCache := true
 	for _, response := range resp.Responses {
 		for _, frame := range response.Frames {

--- a/pkg/awsds/utils_test.go
+++ b/pkg/awsds/utils_test.go
@@ -13,31 +13,43 @@ func TestShouldCacheQuery(t *testing.T) {
 	testcases := []struct {
 		name        string
 		customMeta  map[string]interface{}
+		nilResponse bool
 		shouldCache bool
 	}{
 		{
 			"sync query should cache",
 			map[string]interface{}{"foo": "bar"},
+			false,
 			true,
 		},
 		{
 			"starting async query should cache",
 			map[string]interface{}{"status": "started"},
+			false,
 			true,
 		},
 		{
 			"submitted async query should not cache",
 			map[string]interface{}{"status": "submitted"},
 			false,
+			false,
 		},
 		{
 			"running async query should not cache",
 			map[string]interface{}{"status": "running"},
 			false,
+			false,
 		},
 		{
 			"done async query should cache",
 			map[string]interface{}{"status": "done"},
+			false,
+			true,
+		},
+		{
+			"should handle nil response",
+			nil,
+			true,
 			true,
 		},
 	}
@@ -53,6 +65,9 @@ func TestShouldCacheQuery(t *testing.T) {
 						},
 					},
 				},
+			}
+			if tc.nilResponse {
+				fakeResponse = nil
 			}
 			res := ShouldCacheQuery(fakeResponse)
 			assert.Equal(t, tc.shouldCache, res)


### PR DESCRIPTION
Added handling for nil responses to ShouldCacheQuery, since its intended for use outside this package it should be segfault safe. (even if its unlikely to be used with a nil response)