### PR TITLE
Add Amazon Managed Grafana check in the UserAgent string header

### DIFF
--- a/pkg/awsds/utils.go
+++ b/pkg/awsds/utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -64,7 +65,11 @@ func GetUserAgentString(name string) string {
 		grafanaVersion = "?"
 	}
 
-	return fmt.Sprintf("%s/%s (%s; %s;) %s/%s-%s Grafana/%s",
+	// Determine if running in an Amazon Managed Grafana environment by checking
+	// an environment variable used for the AWS Datasource Provisioner app
+	_, amgEnv := os.LookupEnv("AWS_TRAVERSAL_FETCH")
+
+	return fmt.Sprintf("%s/%s (%s; %s;) %s/%s-%s Grafana/%s AMG/%s",
 		aws.SDKName,
 		aws.SDKVersion,
 		runtime.Version(),
@@ -72,7 +77,8 @@ func GetUserAgentString(name string) string {
 		name,
 		buildInfo.Version,
 		buildInfo.Hash,
-		grafanaVersion)
+		grafanaVersion,
+		strconv.FormatBool(amgEnv))
 }
 
 // getErrorFrameFromQuery returns a error frames with empty data and meta fields

--- a/pkg/awsds/utils.go
+++ b/pkg/awsds/utils.go
@@ -65,9 +65,8 @@ func GetUserAgentString(name string) string {
 		grafanaVersion = "?"
 	}
 
-	// Determine if running in an Amazon Managed Grafana environment by checking
-	// an environment variable used for the AWS Datasource Provisioner app
-	_, amgEnv := os.LookupEnv("AWS_TRAVERSAL_FETCH")
+	// Determine if running in an Amazon Managed Grafana environment
+	_, amgEnv := os.LookupEnv("AMAZON_MANAGED_GRAFANA")
 
 	return fmt.Sprintf("%s/%s (%s; %s;) %s/%s-%s Grafana/%s AMG/%s",
 		aws.SDKName,


### PR DESCRIPTION
To support this issue in the AWS IoT TwinMaker plugin repo: https://github.com/grafana/grafana-iot-twinmaker-app/issues/217

We want to track which of our customers are using Amazon Managed Grafana (AMG) to run this plugin, or a self-managed Grafana server. We can do this by checking the AWS_TRAVERSAL_FETCH variable. This is a configuration option for the AWS Datasource provisioner app, which is only used in AMG.

Adding this check for AMG in each AWS call will allow all AWS services that own Grafana plugins to publish metrics about Grafana and AMG usage. This is particularly important for AWS IoT TwinMaker.

The easiest way to notify AWS IoT TwinMaker is through the [user agent header](https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/pkg/plugin/twinmaker/client.go#L555) in each API call. We already provide information about the Grafana build and runtime version. We should also add whether this is in AMG or not.
* Follow up will remove custom UserAgent logic in the AWS IoT TwinMaker plugin and rely on the grafana-aws-sdk to set the header
