### PR TITLE
DRAFT: exploring sharing logic between sigv4 and sessions

### DIFF
--- a/pkg/auth/auth_settings.go
+++ b/pkg/auth/auth_settings.go
@@ -1,0 +1,61 @@
+package auth
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
+)
+
+// AuthSettings defines whether certain auth types and provider can be used or not
+type AuthSettings struct {
+	AllowedAuthProviders []string
+	AssumeRoleEnabled    bool
+	SessionDuration      *time.Duration
+}
+
+func ReadAuthSettingsFromEnvironmentVariables() *AuthSettings {
+	authSettings := &AuthSettings{}
+	allowedAuthProviders := []string{}
+	providers := os.Getenv(AllowedAuthProvidersEnvVarKeyName)
+	for _, authProvider := range strings.Split(providers, ",") {
+		authProvider = strings.TrimSpace(authProvider)
+		if authProvider != "" {
+			allowedAuthProviders = append(allowedAuthProviders, authProvider)
+		}
+	}
+
+	if len(allowedAuthProviders) == 0 {
+		allowedAuthProviders = []string{"default", "keys", "credentials"}
+		backend.Logger.Warn("could not find allowed auth providers. falling back to 'default, keys, credentials'")
+	}
+	authSettings.AllowedAuthProviders = allowedAuthProviders
+
+	assumeRoleEnabledString := os.Getenv(AssumeRoleEnabledEnvVarKeyName)
+	if len(assumeRoleEnabledString) == 0 {
+		backend.Logger.Warn("environment variable missing. falling back to enable assume role", "var", AssumeRoleEnabledEnvVarKeyName)
+		assumeRoleEnabledString = "true"
+	}
+
+	var err error
+	authSettings.AssumeRoleEnabled, err = strconv.ParseBool(assumeRoleEnabledString)
+	if err != nil {
+		backend.Logger.Error("could not parse env variable", "var", AssumeRoleEnabledEnvVarKeyName)
+		authSettings.AssumeRoleEnabled = true
+	}
+
+	sessionDurationString := os.Getenv(SessionDurationEnvVarKeyName)
+	if sessionDurationString != "" {
+		sessionDuration, err := gtime.ParseDuration(sessionDurationString)
+		if err != nil {
+			backend.Logger.Error("could not parse env variable", "var", SessionDurationEnvVarKeyName)
+		} else {
+			authSettings.SessionDuration = &sessionDuration
+		}
+	}
+
+	return authSettings
+}

--- a/pkg/auth/auth_type.go
+++ b/pkg/auth/auth_type.go
@@ -1,0 +1,87 @@
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+type AuthType int
+
+const (
+	AuthTypeDefault AuthType = iota
+	AuthTypeSharedCreds
+	AuthTypeKeys
+	AuthTypeEC2IAMRole
+	AuthTypeGrafanaAssumeRole //cloud only
+)
+
+func (at AuthType) String() string {
+	switch at {
+	case AuthTypeDefault:
+		return "default"
+	case AuthTypeSharedCreds:
+		return "credentials"
+	case AuthTypeKeys:
+		return "keys"
+	case AuthTypeEC2IAMRole:
+		return "ec2_iam_role"
+	case AuthTypeGrafanaAssumeRole:
+		return "grafana_assume_role"
+	default:
+		panic(fmt.Sprintf("Unrecognized auth type %d", at))
+	}
+}
+
+func ToAuthType(authType string) (AuthType, error) {
+	switch authType {
+	case "credentials", "sharedCreds":
+		return AuthTypeSharedCreds, nil
+	case "keys":
+		return AuthTypeKeys, nil
+	case "default":
+		return AuthTypeDefault, nil
+	case "ec2_iam_role":
+		return AuthTypeEC2IAMRole, nil
+	case "arn":
+		return AuthTypeDefault, nil
+	case "grafana_assume_role":
+		return AuthTypeGrafanaAssumeRole, nil
+	default:
+		return AuthTypeDefault, fmt.Errorf("invalid auth type: %s", authType)
+	}
+}
+
+// MarshalJSON marshals the enum as a quoted json string
+func (at *AuthType) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString(`"`)
+	buffer.WriteString(at.String())
+	buffer.WriteString(`"`)
+	return buffer.Bytes(), nil
+}
+
+// UnmarshalJSON unmarshals a quoted json string to the enum value
+func (at *AuthType) UnmarshalJSON(b []byte) error {
+	var j string
+	err := json.Unmarshal(b, &j)
+	if err != nil {
+		return err
+	}
+	switch j {
+	case "credentials": // Old name
+		fallthrough
+	case "sharedCreds":
+		*at = AuthTypeSharedCreds
+	case "keys":
+		*at = AuthTypeKeys
+	case "ec2_iam_role":
+		*at = AuthTypeEC2IAMRole
+	case "grafana_assume_role":
+		*at = AuthTypeGrafanaAssumeRole
+	case "default":
+		fallthrough
+	default:
+		*at = AuthTypeDefault // For old 'arn' option
+	}
+	return nil
+}

--- a/pkg/auth/constants.go
+++ b/pkg/auth/constants.go
@@ -1,0 +1,20 @@
+package auth
+
+// path to the shared credentials file in the instance for the aws/aws-sdk
+// if empty string, the path is ~/.aws/credentials
+const CredentialsPath = ""
+
+// the profile containing credentials for GrafanaAssueRole auth type in the shared credentials file
+const ProfileName = "assume_role_credentials"
+
+// AllowedAuthProvidersEnvVarKeyName is the string literal for the aws allowed auth providers environment variable key name
+const AllowedAuthProvidersEnvVarKeyName = "AWS_AUTH_AllowedAuthProviders"
+
+// AssumeRoleEnabledEnvVarKeyName is the string literal for the aws assume role enabled environment variable key name
+const AssumeRoleEnabledEnvVarKeyName = "AWS_AUTH_AssumeRoleEnabled"
+
+// SessionDurationEnvVarKeyName is the string literal for the session duration variable key name
+const SessionDurationEnvVarKeyName = "AWS_AUTH_SESSION_DURATION"
+
+// GrafanaAssumeRoleExternalIdKeyName is the string literal for the grafana assume role external id environment variable key name
+const GrafanaAssumeRoleExternalIdKeyName = "AWS_AUTH_EXTERNAL_ID"

--- a/pkg/auth/creds.go
+++ b/pkg/auth/creds.go
@@ -1,0 +1,185 @@
+package auth
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+type CredentialsConfig struct {
+	AuthType string
+
+	Profile string
+
+	AccessKey    string
+	SecretKey    string
+	SessionToken string
+
+	AssumeRoleARN string
+	ExternalID    string
+	Region        string
+	Endpoint      string
+}
+
+func GetCredsFromConfig(cfg CredentialsConfig) (*credentials.Credentials, error) {
+	authType, err := validateAuthType(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return getCredsByAuthType(authType, cfg)
+}
+
+func validateAuthType(cfg CredentialsConfig) (AuthType, error) {
+	authSettings := ReadAuthSettingsFromEnvironmentVariables()
+
+	if cfg.AssumeRoleARN != "" && !authSettings.AssumeRoleEnabled {
+		return 0, fmt.Errorf("attempting to use assume role (ARN) for SigV4 which is not enabled")
+	}
+
+	at, err := ToAuthType(cfg.AuthType)
+	if err != nil {
+		return 0, err
+	}
+
+	authTypeAllowed := false
+	for _, provider := range authSettings.AllowedAuthProviders {
+		if provider == cfg.AuthType {
+			authTypeAllowed = true
+			break
+		}
+	}
+
+	if !authTypeAllowed {
+		return 0, fmt.Errorf("attempting to use an auth type for SigV4 that is not allowed: %q", cfg.AuthType)
+	}
+
+	return at, nil
+}
+
+func getCredsByAuthType(authType AuthType, cfg CredentialsConfig) (*credentials.Credentials, error) {
+	switch authType {
+	case AuthTypeKeys:
+		return getCredsByKeys(cfg)
+	case AuthTypeSharedCreds:
+		return getCredsFromSharedCredsFile(cfg)
+	case AuthTypeGrafanaAssumeRole:
+		return getCredsWithGrafanaAssumeRole(cfg)
+	case AuthTypeEC2IAMRole:
+		return getCredsWithEC2IAMRole(cfg)
+	case AuthTypeDefault:
+		return getCredsWithSDKDefault(cfg)
+	default:
+		// I can't think of a reaason why we'd want to support a default fall-through behavior like this
+		// but to prevent breaking changes, we can keep it for now
+		// in the future it would be great if we can force users to select an authType
+		if cfg.AssumeRoleARN != "" {
+			return getCredsWithSDKDefault(cfg)
+		}
+		return nil, fmt.Errorf("invalid SigV4 auth type")
+	}
+}
+
+func getCredsByKeys(cfg CredentialsConfig) (*credentials.Credentials, error) {
+	primaryCreds := credentials.NewStaticCredentials(cfg.AccessKey, cfg.SecretKey, cfg.SessionToken)
+	if cfg.AssumeRoleARN != "" {
+		return assumeRole(primaryCreds, cfg.AssumeRoleARN, cfg.ExternalID, cfg.Region, cfg.Endpoint)
+	}
+	return primaryCreds, nil
+}
+
+func getCredsFromSharedCredsFile(cfg CredentialsConfig) (*credentials.Credentials, error) {
+	primaryCreds := credentials.NewSharedCredentials("", cfg.Profile)
+	if cfg.AssumeRoleARN != "" {
+		return assumeRole(primaryCreds, cfg.AssumeRoleARN, cfg.ExternalID, cfg.Region, cfg.Endpoint)
+	}
+	return primaryCreds, nil
+}
+
+// Grafana Cloud only feature, under feature toggle awsDatasourcesTempCredentials
+func getCredsWithGrafanaAssumeRole(cfg CredentialsConfig) (*credentials.Credentials, error) {
+	primaryCreds := credentials.NewSharedCredentials(CredentialsPath, ProfileName)
+	if cfg.AssumeRoleARN != "" {
+		return assumeRole(primaryCreds, cfg.AssumeRoleARN, os.Getenv(GrafanaAssumeRoleExternalIdKeyName), cfg.Region, cfg.Endpoint)
+	}
+	return primaryCreds, nil
+}
+
+// Used primarily by AMG
+func getCredsWithEC2IAMRole(cfg CredentialsConfig) (*credentials.Credentials, error) {
+	s, err := session.NewSession(&aws.Config{
+		Region:   aws.String(cfg.Region),
+		Endpoint: aws.String(cfg.Endpoint),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	c := credentials.NewCredentials(defaults.RemoteCredProvider(*s.Config, s.Handlers))
+
+	if cfg.AssumeRoleARN != "" {
+		s, err = session.NewSession(&aws.Config{
+			CredentialsChainVerboseErrors: aws.Bool(true),
+			Region:                        aws.String(cfg.Region),
+			Credentials:                   c,
+			Endpoint:                      aws.String(cfg.Endpoint),
+		})
+		if err != nil {
+			return nil, err
+		}
+		c = stscreds.NewCredentials(s, cfg.AssumeRoleARN)
+	}
+
+	return c, nil
+}
+
+// We do not specify keys to be assumed, instead it gets them from the SDK default credential chain
+// See "Specifying Credentials": https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html
+// Particularly useful for attaching IAM Roles to EC2 instances
+func getCredsWithSDKDefault(cfg CredentialsConfig) (*credentials.Credentials, error) {
+	s, err := session.NewSession(&aws.Config{
+		Region:   aws.String(cfg.Region),
+		Endpoint: aws.String(cfg.Endpoint),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.AssumeRoleARN != "" {
+		return assumeRole(s.Config.Credentials, cfg.AssumeRoleARN, cfg.ExternalID, cfg.Region, cfg.Endpoint)
+	}
+
+	return s.Config.Credentials, nil
+}
+
+func assumeRole(primaryCreds *credentials.Credentials, arn string, externalId string, region string, endpoint string) (*credentials.Credentials, error) {
+	// create a session with the primary credentials
+	s, err := session.NewSession(&aws.Config{
+		Region:      aws.String(region),
+		Credentials: primaryCreds,
+		Endpoint:    aws.String(endpoint),
+	},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// assume role with the primary credentials
+	duration := stscreds.DefaultDuration
+	expiration := time.Now().UTC().Add(duration)
+	stsc := stscreds.NewCredentials(s, arn, func(p *stscreds.AssumeRoleProvider) {
+		// Not sure if this is necessary, overlaps with p.Duration and is undocumented
+		p.Expiry.SetExpiration(expiration, 0)
+		p.Duration = duration
+		if externalId != "" {
+			p.ExternalID = aws.String(externalId)
+		}
+	})
+	return stsc, nil
+}

--- a/pkg/awsds/sessions_test.go
+++ b/pkg/awsds/sessions_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/grafana/grafana-aws-sdk/pkg/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -61,8 +62,8 @@ func TestNewSession_AssumeRole(t *testing.T) {
 		settings := AWSDatasourceSettings{
 			AssumeRoleARN: roleARN,
 		}
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
-		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
+		require.NoError(t, os.Setenv(auth.AllowedAuthProvidersEnvVarKeyName, "default"))
+		require.NoError(t, os.Setenv(auth.AssumeRoleEnabledEnvVarKeyName, "true"))
 		cache := NewSessionCache()
 		sess, err := cache.GetSession(SessionConfig{Settings: settings})
 		require.NoError(t, err)
@@ -85,8 +86,8 @@ func TestNewSession_AssumeRole(t *testing.T) {
 			AssumeRoleARN: roleARN,
 			ExternalID:    externalID,
 		}
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
-		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
+		require.NoError(t, os.Setenv(auth.AllowedAuthProvidersEnvVarKeyName, "default"))
+		require.NoError(t, os.Setenv(auth.AssumeRoleEnabledEnvVarKeyName, "true"))
 		cache := NewSessionCache()
 		sess, err := cache.GetSession(SessionConfig{Settings: settings})
 		require.NoError(t, err)
@@ -108,9 +109,9 @@ func TestNewSession_AssumeRole(t *testing.T) {
 		settings := AWSDatasourceSettings{
 			AssumeRoleARN: roleARN,
 		}
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
-		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
-		require.NoError(t, os.Setenv(SessionDurationEnvVarKeyName, "20m"))
+		require.NoError(t, os.Setenv(auth.AllowedAuthProvidersEnvVarKeyName, "default"))
+		require.NoError(t, os.Setenv(auth.AssumeRoleEnabledEnvVarKeyName, "true"))
+		require.NoError(t, os.Setenv(auth.SessionDurationEnvVarKeyName, "20m"))
 		cache := NewSessionCache()
 		sess, err := cache.GetSession(SessionConfig{Settings: settings})
 		require.NoError(t, err)
@@ -131,8 +132,8 @@ func TestNewSession_AssumeRole(t *testing.T) {
 		settings := AWSDatasourceSettings{
 			AssumeRoleARN: roleARN,
 		}
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
-		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "false"))
+		require.NoError(t, os.Setenv(auth.AllowedAuthProvidersEnvVarKeyName, "default"))
+		require.NoError(t, os.Setenv(auth.AssumeRoleEnabledEnvVarKeyName, "false"))
 		cache := NewSessionCache()
 		sess, err := cache.GetSession(SessionConfig{Settings: settings})
 		require.Error(t, err)
@@ -147,7 +148,7 @@ func TestNewSession_AssumeRole(t *testing.T) {
 		settings := AWSDatasourceSettings{
 			AssumeRoleARN: roleARN,
 		}
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
+		require.NoError(t, os.Setenv(auth.AllowedAuthProvidersEnvVarKeyName, "default"))
 		cache := NewSessionCache()
 		sess, err := cache.GetSession(SessionConfig{Settings: settings})
 		require.NoError(t, err)
@@ -176,8 +177,8 @@ func TestNewSession_AssumeRole(t *testing.T) {
 			AssumeRoleARN: "test",
 			Region:        "me-south-1",
 		}
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
-		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
+		require.NoError(t, os.Setenv(auth.AllowedAuthProvidersEnvVarKeyName, "default"))
+		require.NoError(t, os.Setenv(auth.AssumeRoleEnabledEnvVarKeyName, "true"))
 		cache := NewSessionCache()
 		sess, err := cache.GetSession(SessionConfig{Settings: settings})
 		newSTSCredentials = fakeNewSTSCredentials
@@ -201,8 +202,8 @@ func TestNewSession_AssumeRole(t *testing.T) {
 			AssumeRoleARN: "test",
 			Region:        "us-gov-east-1",
 		}
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
-		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
+		require.NoError(t, os.Setenv(auth.AllowedAuthProvidersEnvVarKeyName, "default"))
+		require.NoError(t, os.Setenv(auth.AssumeRoleEnabledEnvVarKeyName, "true"))
 		cache := NewSessionCache()
 		sess, err := cache.GetSession(SessionConfig{Settings: settings})
 		newSTSCredentials = fakeNewSTSCredentials
@@ -217,9 +218,9 @@ func TestNewSession_AllowedAuthProviders(t *testing.T) {
 	t.Run("Not allowed auth type is used", func(t *testing.T) {
 		defer unsetEnvironmentVariables()
 		settings := AWSDatasourceSettings{
-			AuthType: AuthTypeDefault,
+			AuthType: auth.AuthTypeDefault,
 		}
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "keys"))
+		require.NoError(t, os.Setenv(auth.AllowedAuthProvidersEnvVarKeyName, "keys"))
 		cache := NewSessionCache()
 		sess, err := cache.GetSession(SessionConfig{Settings: settings})
 		require.Error(t, err)
@@ -230,9 +231,9 @@ func TestNewSession_AllowedAuthProviders(t *testing.T) {
 	t.Run("Allowed auth type is used", func(t *testing.T) {
 		defer unsetEnvironmentVariables()
 		settings := AWSDatasourceSettings{
-			AuthType: AuthTypeKeys,
+			AuthType: auth.AuthTypeKeys,
 		}
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "keys"))
+		require.NoError(t, os.Setenv(auth.AllowedAuthProvidersEnvVarKeyName, "keys"))
 		cache := NewSessionCache()
 		sess, err := cache.GetSession(SessionConfig{Settings: settings})
 		require.NoError(t, err)
@@ -240,7 +241,7 @@ func TestNewSession_AllowedAuthProviders(t *testing.T) {
 	})
 
 	t.Run("Fallback is used when AllowedAuthProviders env var is missing", func(t *testing.T) {
-		defaultAuthProviders := []AuthType{AuthTypeDefault, AuthTypeKeys, AuthTypeSharedCreds}
+		defaultAuthProviders := []auth.AuthType{auth.AuthTypeDefault, auth.AuthTypeKeys, auth.AuthTypeSharedCreds}
 		for _, provider := range defaultAuthProviders {
 			defer unsetEnvironmentVariables()
 			settings := AWSDatasourceSettings{
@@ -255,18 +256,18 @@ func TestNewSession_AllowedAuthProviders(t *testing.T) {
 }
 
 func TestNewSession_GrafanaAssumeRole(t *testing.T) {
-	origAllowedAuthProvidersEnvVarKeyName := os.Getenv(AllowedAuthProvidersEnvVarKeyName)
-	origAssumeRoleEnabledEnvVarKeyName := os.Getenv(AssumeRoleEnabledEnvVarKeyName)
+	origAllowedAuthProvidersEnvVarKeyName := os.Getenv(auth.AllowedAuthProvidersEnvVarKeyName)
+	origAssumeRoleEnabledEnvVarKeyName := os.Getenv(auth.AssumeRoleEnabledEnvVarKeyName)
 	origNewSTSCredentials := newSTSCredentials
 	t.Cleanup(func() {
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, origAllowedAuthProvidersEnvVarKeyName))
-		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, origAssumeRoleEnabledEnvVarKeyName))
+		require.NoError(t, os.Setenv(auth.AllowedAuthProvidersEnvVarKeyName, origAllowedAuthProvidersEnvVarKeyName))
+		require.NoError(t, os.Setenv(auth.AssumeRoleEnabledEnvVarKeyName, origAssumeRoleEnabledEnvVarKeyName))
 		newSTSCredentials = origNewSTSCredentials
 	})
 
 	t.Run("externalID is passed to the session", func(t *testing.T) {
-		originalExternalId := os.Getenv(GrafanaAssumeRoleExternalIdKeyName)
-		os.Setenv(GrafanaAssumeRoleExternalIdKeyName, "pretendExternalId")
+		originalExternalId := os.Getenv(auth.GrafanaAssumeRoleExternalIdKeyName)
+		os.Setenv(auth.GrafanaAssumeRoleExternalIdKeyName, "pretendExternalId")
 		newSTSCredentials = func(c client.ConfigProvider, roleARN string,
 			options ...func(*stscreds.AssumeRoleProvider)) *credentials.Credentials {
 			p := &stscreds.AssumeRoleProvider{
@@ -281,17 +282,17 @@ func TestNewSession_GrafanaAssumeRole(t *testing.T) {
 			return credentials.NewCredentials(p)
 		}
 
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "grafana_assume_role"))
-		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
+		require.NoError(t, os.Setenv(auth.AllowedAuthProvidersEnvVarKeyName, "grafana_assume_role"))
+		require.NoError(t, os.Setenv(auth.AssumeRoleEnabledEnvVarKeyName, "true"))
 
 		cache := NewSessionCache()
 		_, err := cache.GetSession(SessionConfig{Settings: AWSDatasourceSettings{
-			AuthType:      AuthTypeGrafanaAssumeRole,
+			AuthType:      auth.AuthTypeGrafanaAssumeRole,
 			AssumeRoleARN: "test_arn",
 		}})
 
 		require.NoError(t, err)
-		os.Setenv(GrafanaAssumeRoleExternalIdKeyName, originalExternalId)
+		os.Setenv(auth.GrafanaAssumeRoleExternalIdKeyName, originalExternalId)
 	})
 
 	t.Run("roleARN is passed to the session", func(t *testing.T) {
@@ -307,12 +308,12 @@ func TestNewSession_GrafanaAssumeRole(t *testing.T) {
 			return credentials.NewCredentials(p)
 		}
 
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "grafana_assume_role"))
-		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
+		require.NoError(t, os.Setenv(auth.AllowedAuthProvidersEnvVarKeyName, "grafana_assume_role"))
+		require.NoError(t, os.Setenv(auth.AssumeRoleEnabledEnvVarKeyName, "true"))
 
 		cache := NewSessionCache()
 		_, err := cache.GetSession(SessionConfig{Settings: AWSDatasourceSettings{
-			AuthType:      AuthTypeGrafanaAssumeRole,
+			AuthType:      auth.AuthTypeGrafanaAssumeRole,
 			AssumeRoleARN: "test_arn",
 		}})
 
@@ -346,12 +347,12 @@ func TestNewSession_EC2IAMRole(t *testing.T) {
 			}, nil
 		}
 		settings := AWSDatasourceSettings{
-			AuthType: AuthTypeEC2IAMRole,
+			AuthType: auth.AuthTypeEC2IAMRole,
 			Endpoint: "foo",
 		}
 
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "ec2_iam_role"))
-		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
+		require.NoError(t, os.Setenv(auth.AllowedAuthProvidersEnvVarKeyName, "ec2_iam_role"))
+		require.NoError(t, os.Setenv(auth.AssumeRoleEnabledEnvVarKeyName, "true"))
 
 		cache := NewSessionCache()
 		sess, err := cache.GetSession(SessionConfig{Settings: settings})
@@ -376,15 +377,15 @@ func TestNewSession_EC2IAMRole(t *testing.T) {
 }
 
 func unsetEnvironmentVariables() {
-	os.Unsetenv(AllowedAuthProvidersEnvVarKeyName)
-	os.Unsetenv(AssumeRoleEnabledEnvVarKeyName)
-	os.Unsetenv(SessionDurationEnvVarKeyName)
+	os.Unsetenv(auth.AllowedAuthProvidersEnvVarKeyName)
+	os.Unsetenv(auth.AssumeRoleEnabledEnvVarKeyName)
+	os.Unsetenv(auth.SessionDurationEnvVarKeyName)
 }
 
 func TestWithUserAgent(t *testing.T) {
 	defer unsetEnvironmentVariables()
-	require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
-	require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "false"))
+	require.NoError(t, os.Setenv(auth.AllowedAuthProvidersEnvVarKeyName, "default"))
+	require.NoError(t, os.Setenv(auth.AssumeRoleEnabledEnvVarKeyName, "false"))
 	cache := NewSessionCache()
 	sess, err := cache.GetSession(SessionConfig{UserAgentName: aws.String("Athena")})
 	require.NoError(t, err)
@@ -400,8 +401,8 @@ func TestWithUserAgent(t *testing.T) {
 
 func TestWithCustomHTTPClient(t *testing.T) {
 	defer unsetEnvironmentVariables()
-	require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
-	require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "false"))
+	require.NoError(t, os.Setenv(auth.AllowedAuthProvidersEnvVarKeyName, "default"))
+	require.NoError(t, os.Setenv(auth.AssumeRoleEnabledEnvVarKeyName, "false"))
 	cache := NewSessionCache()
 	sess, err := cache.GetSession(SessionConfig{
 		HTTPClient: &http.Client{Timeout: 123},

--- a/pkg/awsds/settings.go
+++ b/pkg/awsds/settings.go
@@ -1,102 +1,22 @@
 package awsds
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 
+	"github.com/grafana/grafana-aws-sdk/pkg/auth"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
 const defaultRegion = "default"
 
-type AuthType int
-
-const (
-	AuthTypeDefault AuthType = iota
-	AuthTypeSharedCreds
-	AuthTypeKeys
-	AuthTypeEC2IAMRole
-	AuthTypeGrafanaAssumeRole //cloud only
-)
-
-func (at AuthType) String() string {
-	switch at {
-	case AuthTypeDefault:
-		return "default"
-	case AuthTypeSharedCreds:
-		return "credentials"
-	case AuthTypeKeys:
-		return "keys"
-	case AuthTypeEC2IAMRole:
-		return "ec2_iam_role"
-	case AuthTypeGrafanaAssumeRole:
-		return "grafana_assume_role"
-	default:
-		panic(fmt.Sprintf("Unrecognized auth type %d", at))
-	}
-}
-
-func ToAuthType(authType string) (AuthType, error) {
-	switch authType {
-	case "credentials", "sharedCreds":
-		return AuthTypeSharedCreds, nil
-	case "keys":
-		return AuthTypeKeys, nil
-	case "default":
-		return AuthTypeDefault, nil
-	case "ec2_iam_role":
-		return AuthTypeEC2IAMRole, nil
-	case "arn":
-		return AuthTypeDefault, nil
-	case "grafana_assume_role":
-		return AuthTypeGrafanaAssumeRole, nil
-	default:
-		return AuthTypeDefault, fmt.Errorf("invalid auth type: %s", authType)
-	}
-}
-
-// MarshalJSON marshals the enum as a quoted json string
-func (at *AuthType) MarshalJSON() ([]byte, error) {
-	buffer := bytes.NewBufferString(`"`)
-	buffer.WriteString(at.String())
-	buffer.WriteString(`"`)
-	return buffer.Bytes(), nil
-}
-
-// UnmarshalJSON unmashals a quoted json string to the enum value
-func (at *AuthType) UnmarshalJSON(b []byte) error {
-	var j string
-	err := json.Unmarshal(b, &j)
-	if err != nil {
-		return err
-	}
-	switch j {
-	case "credentials": // Old name
-		fallthrough
-	case "sharedCreds":
-		*at = AuthTypeSharedCreds
-	case "keys":
-		*at = AuthTypeKeys
-	case "ec2_iam_role":
-		*at = AuthTypeEC2IAMRole
-	case "grafana_assume_role":
-		*at = AuthTypeGrafanaAssumeRole
-	case "default":
-		fallthrough
-	default:
-		*at = AuthTypeDefault // For old 'arn' option
-	}
-	return nil
-}
-
 // DatasourceSettings holds basic connection info
 type AWSDatasourceSettings struct {
-	Profile       string   `json:"profile"`
-	Region        string   `json:"region"`
-	AuthType      AuthType `json:"authType"`
-	AssumeRoleARN string   `json:"assumeRoleARN"`
-	ExternalID    string   `json:"externalId"`
+	Profile       string        `json:"profile"`
+	Region        string        `json:"region"`
+	AuthType      auth.AuthType `json:"authType"`
+	AssumeRoleARN string        `json:"assumeRoleARN"`
+	ExternalID    string        `json:"externalId"`
 
 	// Override the client endpoint
 	Endpoint string `json:"endpoint"`

--- a/pkg/awsds/settings_test.go
+++ b/pkg/awsds/settings_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/grafana/grafana-aws-sdk/pkg/auth"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/stretchr/testify/assert"
 )
@@ -12,7 +13,7 @@ import (
 // Test load settings from json
 func TestLoadSettings(t *testing.T) {
 	settings := &AWSDatasourceSettings{
-		AuthType:      AuthTypeKeys,
+		AuthType:      auth.AuthTypeKeys,
 		DefaultRegion: "aaaa",
 	}
 

--- a/pkg/awsds/types.go
+++ b/pkg/awsds/types.go
@@ -5,7 +5,6 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -14,13 +13,6 @@ import (
 
 // AmazonSessionProvider will return a session (perhaps cached) for given region and settings
 type AmazonSessionProvider func(region string, s AWSDatasourceSettings) (*session.Session, error)
-
-// AuthSettings defines whether certain auth types and provider can be used or not
-type AuthSettings struct {
-	AllowedAuthProviders []string
-	AssumeRoleEnabled    bool
-	SessionDuration      *time.Duration
-}
 
 // QueryStatus represents the status of an async query
 type QueryStatus uint32

--- a/pkg/sigv4/sigv4_test.go
+++ b/pkg/sigv4/sigv4_test.go
@@ -17,14 +17,13 @@ import (
 
 func TestNew(t *testing.T) {
 	t.Run("Can't create new middleware without valid auth type", func(t *testing.T) {
-		rt, err := New(&Config{}, nil)
+		rt, err := New(&SigV4Config{}, nil)
 		require.Error(t, err)
 		require.Nil(t, rt)
-
 	})
 	t.Run("Can create new middleware with any valid auth type", func(t *testing.T) {
-		for _, authType := range []string{"credentials", "sharedCreds", "keys", "default", "ec2_iam_role", "arn"} {
-			rt, err := New(&Config{AuthType: authType}, nil)
+		for _, authType := range []string{"credentials", "sharedCreds", "keys", "default", "ec2_iam_role", "arn", "grafana_assume_role"} {
+			rt, err := New(&SigV4Config{AuthType: authType}, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, rt)
@@ -32,7 +31,7 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("Can sign a request", func(t *testing.T) {
-		cfg := &Config{AuthType: "default"}
+		cfg := &SigV4Config{AuthType: "default"}
 		rt, err := New(cfg, &fakeTransport{})
 		require.NoError(t, err)
 		require.NotNil(t, rt)
@@ -62,7 +61,7 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("Can sign a request with extra headers which are not signed", func(t *testing.T) {
-		cfg := &Config{AuthType: "default"}
+		cfg := &SigV4Config{AuthType: "default"}
 		rt, err := New(cfg, &fakeTransport{})
 		require.NoError(t, err)
 		require.NotNil(t, rt)
@@ -95,7 +94,7 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("Signed request overwrites existing Authorization header", func(t *testing.T) {
-		cfg := &Config{AuthType: "default"}
+		cfg := &SigV4Config{AuthType: "default"}
 		rt, err := New(cfg, &fakeTransport{})
 		require.NoError(t, err)
 		require.NotNil(t, rt)
@@ -121,7 +120,7 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("Can't sign a request without valid credentials", func(t *testing.T) {
-		cfg := &Config{AuthType: "ec2_iam_role"}
+		cfg := &SigV4Config{AuthType: "ec2_iam_role"}
 		rt, err := New(cfg, &fakeTransport{})
 		require.NoError(t, err)
 		require.NotNil(t, rt)
@@ -139,7 +138,7 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("Will log requests during signing if verboseMode is true", func(t *testing.T) {
-		cfg := &Config{AuthType: "ec2_iam_role"}
+		cfg := &SigV4Config{AuthType: "ec2_iam_role"}
 
 		// Mock logger
 		origLogger := backend.Logger
@@ -171,7 +170,7 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("Will not log requests during signing if verboseMode is false", func(t *testing.T) {
-		cfg := &Config{AuthType: "ec2_iam_role"}
+		cfg := &SigV4Config{AuthType: "ec2_iam_role"}
 
 		// Mock logger
 		origLogger := backend.Logger
@@ -203,7 +202,7 @@ func TestNew(t *testing.T) {
 
 func TestConfig(t *testing.T) {
 	t.Run("SHA generation is consistent", func(t *testing.T) {
-		cfg := &Config{
+		cfg := &SigV4Config{
 			AuthType:      "A",
 			Profile:       "B",
 			Service:       "C",
@@ -225,7 +224,7 @@ func TestConfig(t *testing.T) {
 	})
 
 	t.Run("Config field order does not affect SHA", func(t *testing.T) {
-		cfg1 := &Config{
+		cfg1 := &SigV4Config{
 			AuthType:      "A",
 			Profile:       "B",
 			Service:       "C",
@@ -237,7 +236,7 @@ func TestConfig(t *testing.T) {
 			Region:        "I",
 		}
 
-		cfg2 := &Config{
+		cfg2 := &SigV4Config{
 			Region:        "I",
 			ExternalID:    "H",
 			AssumeRoleARN: "G",
@@ -259,7 +258,7 @@ func TestConfig(t *testing.T) {
 	})
 
 	t.Run("Config SHA changes depending on contents", func(t *testing.T) {
-		cfg1 := &Config{
+		cfg1 := &SigV4Config{
 			AuthType:      "A",
 			Profile:       "B",
 			Service:       "C",
@@ -271,7 +270,7 @@ func TestConfig(t *testing.T) {
 			Region:        "I",
 		}
 
-		cfg2 := &Config{
+		cfg2 := &SigV4Config{
 			AuthType:      "AB",
 			Profile:       "B",
 			Service:       "C",


### PR DESCRIPTION
The logic for getting credentials from aws is _nearly_ the same if you are fetching those credentials to sign requests vs if you are using those credentials to create a session object that is passed to the aws-sdk, and yet our code between the two is in separate places. 

As we work to add more code to this, I wanted to explore if it would perhaps make sense to abstract this out in some way. I did a bit of an incomplete spike on this and I think it does make sense. I think I spotted a few bugs in this work (our sigv4 doesn't seem to support endpoint for example, and maybe doesn't use externalids correctly?), and I think having this fairly complicated logic in 2 different places is just very difficult to maintain. 

That said it feels a bit scary to just merge something like this (even if I added many tests). This code is fairly high impact, and I'm not even sure I know all the datasources that consume our sigv4 code, (I think Opensearch and Prometheus?) so manual testing would likely be incomplete. 

In an ideal world, I think we'd write this code in such a way that we were behind a feature toggle and slowly release over time. But my understanding is that our current feature toggles can not be used in the backend in external plugins so we'd either have to update our frontend to hit different endpoints based on feature toggle or we'd have to go about this without feature toggles. Maybe just abstracting a little bit over time over a series of prs? 

I also don't think our team actually owns the sigv4 code here, which is arguably intentional? I think for now I'm going to put down this work for a bit and save it in a draft. Maybe we can revisit at another time.