### PR TITLE
Adding support for temporary credentials to sigv4 workflows

### DIFF
--- a/pkg/sigv4/sigv4.go
+++ b/pkg/sigv4/sigv4.go
@@ -236,7 +236,6 @@ func createSigner(cfg *Config, verboseMode bool) (*v4.Signer, error) {
 			// Not sure if this is necessary, overlaps with p.Duration and is undocumented
 			p.Expiry.SetExpiration(expiration, 0)
 			p.Duration = duration
-			backend.Logger.Info("os.Getenv(awsds.GrafanaAssumeRoleExternalIdKeyName)", "os.Getenv(awsds.GrafanaAssumeRoleExternalIdKeyName)", os.Getenv(awsds.GrafanaAssumeRoleExternalIdKeyName))
 			p.ExternalID = aws.String(os.Getenv(awsds.GrafanaAssumeRoleExternalIdKeyName))
 		})
 		return v4.NewSigner(tempCreds, signerOpts), nil

--- a/pkg/sigv4/sigv4_test.go
+++ b/pkg/sigv4/sigv4_test.go
@@ -23,7 +23,7 @@ func TestNew(t *testing.T) {
 
 	})
 	t.Run("Can create new middleware with any valid auth type", func(t *testing.T) {
-		for _, authType := range []string{"credentials", "sharedCreds", "keys", "default", "ec2_iam_role", "arn"} {
+		for _, authType := range []string{"credentials", "sharedCreds", "keys", "default", "ec2_iam_role", "arn", "grafana_assume_role"} {
 			rt, err := New(&Config{AuthType: authType}, nil)
 
 			require.NoError(t, err)


### PR DESCRIPTION
The primary motivation here is to support Temporary Credentials in Opensearch.

There's some additional work we'll have to do in opensearch before that is fully possible but this is a good step of the way there. 

To test locally:
- pull down https://github.com/grafana/grafana-aws-sdk-react/pull/66 yarn watch, then yarn link and link in opensearch
- pull down this branch and add `replace github.com/grafana/grafana-aws-sdk => /Users/sarahzinger/code/grafana/grafana-aws-sdk` to go.mod of opensearch
- (grafana internal only) see provisioning instructions here: https://github.com/grafana/plugin-provisioning/pull/137, take note of comments section with instructions for custom.ini file and .aws/credentials file
- run mage in opensearch
- make run in main grafana
- set up a new datasource as described ^ 
- save + test is expected to fail because we do not use the same backend flow yet for the health check, so for now ignore
- go to explore and select datasource, metrics should fetch successfully

This really needs tests but I found it difficult to do so. Maybe someone wants to pair with me on it? My attempts lead me to try to a larger refactor project: https://github.com/grafana/grafana-aws-sdk/pull/103 but it felt like scope creep.