### PR TITLE
Include invalid sigV4 authType in error message

### DIFF
--- a/pkg/sigv4/sigv4.go
+++ b/pkg/sigv4/sigv4.go
@@ -262,7 +262,7 @@ func createSigner(cfg *Config, verboseMode bool) (*v4.Signer, error) {
 			}
 			return v4.NewSigner(stscreds.NewCredentials(s, cfg.AssumeRoleARN), signerOpts), nil
 		}
-		return nil, fmt.Errorf("invalid SigV4 auth type")
+		return nil, fmt.Errorf("invalid SigV4 auth type %q", authType)
 	}
 
 	if cfg.AssumeRoleARN != "" {


### PR DESCRIPTION
This PR adds the authType to the error message when it is invalid for SigV4.

This came up in [this issue report](https://github.com/grafana/opensearch-datasource/issues/288) and it would have been nice if the authType showed up in the logs there.