### PR TITLE
Add ca-west-1 to list of opt-in regions

### DIFF
--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -144,6 +144,7 @@ func isOptInRegion(region string) bool {
 		"ap-south-2":     true,
 		"ap-southeast-3": true,
 		"ap-southeast-4": true,
+		"ca-west-1":	  true,
 		"eu-central-2":   true,
 		"eu-south-1":     true,
 		"eu-south-2":     true,


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana-aws-sdk/issues/110 by adding the ca-west-1 region to the list of opt in regions