### PR TITLE
Deprecate using environment variables for auth settings in sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.23.0
+
+- Deprecate using environment variables for auth settings in sessions [#121](https://github.com/grafana/grafana-aws-sdk/pull/121)
+
 ## v0.22.0
 
 - Add ReadAuthSettings to get config settings from context [#118](https://github.com/grafana/grafana-aws-sdk/pull/118)

--- a/pkg/awsds/authSettings.go
+++ b/pkg/awsds/authSettings.go
@@ -91,6 +91,15 @@ func ReadAuthSettingsFromContext(ctx context.Context) (*AuthSettings, bool) {
 		hasSettings = true
 	}
 
+	if v := cfg.Get(SessionDurationEnvVarKeyName); v != "" {
+		sessionDuration, err := gtime.ParseDuration(v)
+		if err == nil {
+			settings.SessionDuration = &sessionDuration
+		} else {
+			backend.Logger.Error("could not parse env variable", "var", SessionDurationEnvVarKeyName)
+		}
+	}
+
 	if v := cfg.Get(GrafanaListMetricsPageLimit); v != "" {
 		listMetricsPageLimit, err := strconv.Atoi(v)
 		if err == nil {
@@ -109,17 +118,6 @@ func ReadAuthSettingsFromContext(ctx context.Context) (*AuthSettings, bool) {
 			backend.Logger.Error("could not parse context variable", "var", proxy.PluginSecureSocksProxyEnabled)
 		}
 		hasSettings = true
-	}
-
-	// Users set session duration directly as an environment variable
-	sessionDurationString := os.Getenv(SessionDurationEnvVarKeyName)
-	if sessionDurationString != "" {
-		sessionDuration, err := gtime.ParseDuration(sessionDurationString)
-		if err == nil {
-			settings.SessionDuration = &sessionDuration
-		} else {
-			backend.Logger.Error("could not parse env variable", "var", SessionDurationEnvVarKeyName)
-		}
 	}
 
 	return settings, hasSettings

--- a/pkg/awsds/authSettings.go
+++ b/pkg/awsds/authSettings.go
@@ -25,8 +25,8 @@ const (
 	// GrafanaAssumeRoleExternalIdKeyName is the string literal for the grafana assume role external id environment variable key name
 	GrafanaAssumeRoleExternalIdKeyName = "AWS_AUTH_EXTERNAL_ID"
 
-	// GrafanaListMetricsPageLimit is the string literal for the cloudwatch list metrics page limit key name
-	GrafanaListMetricsPageLimit = "AWS_CW_LIST_METRICS_PAGE_LIMIT"
+	// ListMetricsPageLimitKeyName is the string literal for the cloudwatch list metrics page limit key name
+	ListMetricsPageLimitKeyName = "AWS_CW_LIST_METRICS_PAGE_LIMIT"
 
 	defaultAssumeRoleEnabled         = true
 	defaultListMetricsPageLimit      = 500
@@ -100,12 +100,12 @@ func ReadAuthSettingsFromContext(ctx context.Context) (*AuthSettings, bool) {
 		}
 	}
 
-	if v := cfg.Get(GrafanaListMetricsPageLimit); v != "" {
+	if v := cfg.Get(ListMetricsPageLimitKeyName); v != "" {
 		listMetricsPageLimit, err := strconv.Atoi(v)
 		if err == nil {
 			settings.ListMetricsPageLimit = listMetricsPageLimit
 		} else {
-			backend.Logger.Error("could not parse context variable", "var", GrafanaListMetricsPageLimit)
+			backend.Logger.Error("could not parse context variable", "var", ListMetricsPageLimitKeyName)
 		}
 		hasSettings = true
 	}
@@ -157,15 +157,15 @@ func ReadAuthSettingsFromEnvironmentVariables() *AuthSettings {
 
 	authSettings.ExternalID = os.Getenv(GrafanaAssumeRoleExternalIdKeyName)
 
-	listMetricsPageLimitString := os.Getenv(GrafanaListMetricsPageLimit)
+	listMetricsPageLimitString := os.Getenv(ListMetricsPageLimitKeyName)
 	if len(listMetricsPageLimitString) == 0 {
-		backend.Logger.Warn("environment variable missing. falling back to default page limit", "var", GrafanaListMetricsPageLimit)
+		backend.Logger.Warn("environment variable missing. falling back to default page limit", "var", ListMetricsPageLimitKeyName)
 		listMetricsPageLimitString = "500"
 	}
 
 	authSettings.ListMetricsPageLimit, err = strconv.Atoi(listMetricsPageLimitString)
 	if err != nil {
-		backend.Logger.Error("could not parse env variable", "var", GrafanaListMetricsPageLimit)
+		backend.Logger.Error("could not parse env variable", "var", ListMetricsPageLimitKeyName)
 		authSettings.ListMetricsPageLimit = defaultListMetricsPageLimit
 	}
 

--- a/pkg/awsds/authSettings_test.go
+++ b/pkg/awsds/authSettings_test.go
@@ -49,7 +49,7 @@ func TestReadAuthSettingsFromContext(t *testing.T) {
 				AllowedAuthProvidersEnvVarKeyName:   "foo , bar,baz",
 				AssumeRoleEnabledEnvVarKeyName:      "false",
 				GrafanaAssumeRoleExternalIdKeyName:  "mock_id",
-				GrafanaListMetricsPageLimit:         "50",
+				ListMetricsPageLimitKeyName:         "50",
 				proxy.PluginSecureSocksProxyEnabled: "true",
 			}),
 			expectedSettings: &AuthSettings{
@@ -81,8 +81,8 @@ func TestReadAuthSettings(t *testing.T) {
 		os.Setenv(GrafanaAssumeRoleExternalIdKeyName, originalExternalId)
 	}()
 
-	var ctxDuration time.Duration = 600000000000  // 10 minutes in nanoseconds count
-	var envDuration time.Duration = 1200000000000 // 20 minutes in nanoseconds count
+	ctxDuration := 10 * time.Minute
+	envDuration := 20 * time.Minute
 	expectedSessionContextSettings := &AuthSettings{
 		AllowedAuthProviders:      []string{"foo", "bar", "baz"},
 		AssumeRoleEnabled:         false,
@@ -101,7 +101,7 @@ func TestReadAuthSettings(t *testing.T) {
 		SecureSocksDSProxyEnabled: false,
 	}
 
-	require.NoError(t, os.Setenv(GrafanaListMetricsPageLimit, "30"))
+	require.NoError(t, os.Setenv(ListMetricsPageLimitKeyName, "30"))
 	require.NoError(t, os.Setenv(SessionDurationEnvVarKeyName, "20m"))
 	require.NoError(t, os.Setenv(proxy.PluginSecureSocksProxyEnabled, "false"))
 	defer unsetEnvironmentVariables()
@@ -138,7 +138,7 @@ func TestReadAuthSettings(t *testing.T) {
 				AssumeRoleEnabledEnvVarKeyName:      "false",
 				SessionDurationEnvVarKeyName:        "10m",
 				GrafanaAssumeRoleExternalIdKeyName:  "mock_id",
-				GrafanaListMetricsPageLimit:         "50",
+				ListMetricsPageLimitKeyName:         "50",
 				proxy.PluginSecureSocksProxyEnabled: "true",
 			}),
 			expectedSettings: expectedSessionContextSettings,
@@ -159,5 +159,5 @@ func unsetEnvironmentVariables() {
 	os.Unsetenv(AllowedAuthProvidersEnvVarKeyName)
 	os.Unsetenv(AssumeRoleEnabledEnvVarKeyName)
 	os.Unsetenv(SessionDurationEnvVarKeyName)
-	os.Unsetenv(GrafanaListMetricsPageLimit)
+	os.Unsetenv(ListMetricsPageLimitKeyName)
 }

--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -105,6 +105,9 @@ func (sc *SessionCache) GetSession(c SessionConfig) (*session.Session, error) {
 		// DefaultRegion is deprecated, Region should be used instead
 		c.Settings.Region = c.Settings.DefaultRegion
 	}
+
+	// If the datasource calling GetSession is getting the settings from the contexts, they'll pass
+	// the values through AuthSettings. Otherwise, we need to get them from the env variables.
 	if c.AuthSettings == nil {
 		c.AuthSettings = ReadAuthSettingsFromEnvironmentVariables()
 	}

--- a/pkg/awsds/sessions_test.go
+++ b/pkg/awsds/sessions_test.go
@@ -3,7 +3,6 @@ package awsds
 import (
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -56,15 +55,18 @@ func TestNewSession_AssumeRole(t *testing.T) {
 	duration := stscreds.DefaultDuration
 
 	t.Run("Without external ID", func(t *testing.T) {
-		defer unsetEnvironmentVariables()
 		const roleARN = "test"
 		settings := AWSDatasourceSettings{
 			AssumeRoleARN: roleARN,
 		}
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
-		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
 		cache := NewSessionCache()
-		sess, err := cache.GetSession(SessionConfig{Settings: settings})
+		sess, err := cache.GetSession(SessionConfig{
+			Settings: settings,
+			AuthSettings: &AuthSettings{
+				AllowedAuthProviders: []string{"default"},
+				AssumeRoleEnabled:    true,
+			},
+		})
 		require.NoError(t, err)
 		require.NotNil(t, sess)
 		expCreds := credentials.NewCredentials(&stscreds.AssumeRoleProvider{
@@ -78,17 +80,20 @@ func TestNewSession_AssumeRole(t *testing.T) {
 	})
 
 	t.Run("With external ID", func(t *testing.T) {
-		defer unsetEnvironmentVariables()
 		const roleARN = "test"
 		const externalID = "external"
 		settings := AWSDatasourceSettings{
 			AssumeRoleARN: roleARN,
 			ExternalID:    externalID,
 		}
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
-		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
 		cache := NewSessionCache()
-		sess, err := cache.GetSession(SessionConfig{Settings: settings})
+		sess, err := cache.GetSession(SessionConfig{
+			Settings: settings,
+			AuthSettings: &AuthSettings{
+				AllowedAuthProviders: []string{"default"},
+				AssumeRoleEnabled:    true,
+			},
+		})
 		require.NoError(t, err)
 		require.NotNil(t, sess)
 		expCreds := credentials.NewCredentials(&stscreds.AssumeRoleProvider{
@@ -103,21 +108,25 @@ func TestNewSession_AssumeRole(t *testing.T) {
 	})
 
 	t.Run("With custom duration", func(t *testing.T) {
-		defer unsetEnvironmentVariables()
 		const roleARN = "test"
 		settings := AWSDatasourceSettings{
 			AssumeRoleARN: roleARN,
 		}
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
-		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
-		require.NoError(t, os.Setenv(SessionDurationEnvVarKeyName, "20m"))
+		var expectedDuration time.Duration = 1200000000000 //20 minutes in nanoseconds count
 		cache := NewSessionCache()
-		sess, err := cache.GetSession(SessionConfig{Settings: settings})
+		sess, err := cache.GetSession(SessionConfig{
+			Settings: settings,
+			AuthSettings: &AuthSettings{
+				AllowedAuthProviders: []string{"default"},
+				AssumeRoleEnabled:    true,
+				SessionDuration:      &expectedDuration,
+			},
+		})
 		require.NoError(t, err)
 		require.NotNil(t, sess)
 		expCreds := credentials.NewCredentials(&stscreds.AssumeRoleProvider{
 			RoleARN:  roleARN,
-			Duration: 1200000000000, //20 minutes in nanoseconds count
+			Duration: expectedDuration,
 		})
 		diff := cmp.Diff(expCreds, sess.Config.Credentials, cmp.Exporter(func(_ reflect.Type) bool {
 			return true
@@ -126,44 +135,25 @@ func TestNewSession_AssumeRole(t *testing.T) {
 	})
 
 	t.Run("Assume role not enabled", func(t *testing.T) {
-		defer unsetEnvironmentVariables()
 		const roleARN = "test"
 		settings := AWSDatasourceSettings{
 			AssumeRoleARN: roleARN,
 		}
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
-		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "false"))
 		cache := NewSessionCache()
-		sess, err := cache.GetSession(SessionConfig{Settings: settings})
+		sess, err := cache.GetSession(SessionConfig{
+			Settings: settings,
+			AuthSettings: &AuthSettings{
+				AllowedAuthProviders: []string{"default"},
+				AssumeRoleEnabled:    false,
+			},
+		})
 		require.Error(t, err)
 		require.Nil(t, sess)
 		expectedError := "attempting to use assume role (ARN) which is disabled in grafana.ini"
 		assert.Equal(t, expectedError, err.Error())
 	})
 
-	t.Run("Assume role is enabled when AssumeRoleEnabled env var is missing", func(t *testing.T) {
-		defer unsetEnvironmentVariables()
-		const roleARN = "test"
-		settings := AWSDatasourceSettings{
-			AssumeRoleARN: roleARN,
-		}
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
-		cache := NewSessionCache()
-		sess, err := cache.GetSession(SessionConfig{Settings: settings})
-		require.NoError(t, err)
-		require.NotNil(t, sess)
-		expCreds := credentials.NewCredentials(&stscreds.AssumeRoleProvider{
-			RoleARN:  roleARN,
-			Duration: duration,
-		})
-		diff := cmp.Diff(expCreds, sess.Config.Credentials, cmp.Exporter(func(_ reflect.Type) bool {
-			return true
-		}), cmpopts.IgnoreFields(stscreds.AssumeRoleProvider{}, "Expiry"))
-		assert.Empty(t, diff)
-	})
-
 	t.Run("Assume role is enabled with an opt-in region", func(t *testing.T) {
-		defer unsetEnvironmentVariables()
 		fakeNewSTSCredentials := newSTSCredentials
 		newSTSCredentials = func(c client.ConfigProvider, roleARN string,
 			options ...func(*stscreds.AssumeRoleProvider)) *credentials.Credentials {
@@ -176,10 +166,14 @@ func TestNewSession_AssumeRole(t *testing.T) {
 			AssumeRoleARN: "test",
 			Region:        "me-south-1",
 		}
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
-		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
 		cache := NewSessionCache()
-		sess, err := cache.GetSession(SessionConfig{Settings: settings})
+		sess, err := cache.GetSession(SessionConfig{
+			Settings: settings,
+			AuthSettings: &AuthSettings{
+				AllowedAuthProviders: []string{"default"},
+				AssumeRoleEnabled:    true,
+			},
+		})
 		newSTSCredentials = fakeNewSTSCredentials
 
 		require.NoError(t, err)
@@ -188,7 +182,6 @@ func TestNewSession_AssumeRole(t *testing.T) {
 	})
 
 	t.Run("Assume role is enabled with a gov region", func(t *testing.T) {
-		defer unsetEnvironmentVariables()
 		fakeNewSTSCredentials := newSTSCredentials
 		newSTSCredentials = func(c client.ConfigProvider, roleARN string,
 			options ...func(*stscreds.AssumeRoleProvider)) *credentials.Credentials {
@@ -201,10 +194,14 @@ func TestNewSession_AssumeRole(t *testing.T) {
 			AssumeRoleARN: "test",
 			Region:        "us-gov-east-1",
 		}
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
-		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
 		cache := NewSessionCache()
-		sess, err := cache.GetSession(SessionConfig{Settings: settings})
+		sess, err := cache.GetSession(SessionConfig{
+			Settings: settings,
+			AuthSettings: &AuthSettings{
+				AllowedAuthProviders: []string{"default"},
+				AssumeRoleEnabled:    true,
+			},
+		})
 		newSTSCredentials = fakeNewSTSCredentials
 
 		require.NoError(t, err)
@@ -213,7 +210,6 @@ func TestNewSession_AssumeRole(t *testing.T) {
 	})
 
 	t.Run("Assume role is enabled with a fips endpoint", func(t *testing.T) {
-		defer unsetEnvironmentVariables()
 		fakeNewSTSCredentials := newSTSCredentials
 		newSTSCredentials = func(c client.ConfigProvider, roleARN string,
 			options ...func(*stscreds.AssumeRoleProvider)) *credentials.Credentials {
@@ -227,10 +223,14 @@ func TestNewSession_AssumeRole(t *testing.T) {
 			Region:        "us-east-1",
 			Endpoint:      "athena-fips.us-east-1.amazonaws.com",
 		}
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
-		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
 		cache := NewSessionCache()
-		sess, err := cache.GetSession(SessionConfig{Settings: settings})
+		sess, err := cache.GetSession(SessionConfig{
+			Settings: settings,
+			AuthSettings: &AuthSettings{
+				AllowedAuthProviders: []string{"default"},
+				AssumeRoleEnabled:    true,
+			},
+		})
 		newSTSCredentials = fakeNewSTSCredentials
 
 		require.NoError(t, err)
@@ -242,31 +242,37 @@ func TestNewSession_AssumeRole(t *testing.T) {
 
 func TestNewSession_AllowedAuthProviders(t *testing.T) {
 	t.Run("Not allowed auth type is used", func(t *testing.T) {
-		defer unsetEnvironmentVariables()
 		settings := AWSDatasourceSettings{
 			AuthType: AuthTypeDefault,
 		}
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "keys"))
 		cache := NewSessionCache()
-		sess, err := cache.GetSession(SessionConfig{Settings: settings})
+		sess, err := cache.GetSession(SessionConfig{
+			Settings: settings,
+			AuthSettings: &AuthSettings{
+				AllowedAuthProviders: []string{"key"},
+			},
+		})
 		require.Error(t, err)
 		require.Nil(t, sess)
 		assert.Equal(t, `attempting to use an auth type that is not allowed: "default"`, err.Error())
 	})
 
 	t.Run("Allowed auth type is used", func(t *testing.T) {
-		defer unsetEnvironmentVariables()
 		settings := AWSDatasourceSettings{
 			AuthType: AuthTypeKeys,
 		}
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "keys"))
 		cache := NewSessionCache()
-		sess, err := cache.GetSession(SessionConfig{Settings: settings})
+		sess, err := cache.GetSession(SessionConfig{
+			Settings: settings,
+			AuthSettings: &AuthSettings{
+				AllowedAuthProviders: []string{"keys"},
+			},
+		})
 		require.NoError(t, err)
 		require.NotNil(t, sess)
 	})
 
-	t.Run("Fallback is used when AllowedAuthProviders env var is missing", func(t *testing.T) {
+	t.Run("Env var fallback is used when auth settings aren't sent", func(t *testing.T) {
 		defaultAuthProviders := []AuthType{AuthTypeDefault, AuthTypeKeys, AuthTypeSharedCreds}
 		for _, provider := range defaultAuthProviders {
 			defer unsetEnvironmentVariables()
@@ -282,18 +288,12 @@ func TestNewSession_AllowedAuthProviders(t *testing.T) {
 }
 
 func TestNewSession_GrafanaAssumeRole(t *testing.T) {
-	origAllowedAuthProvidersEnvVarKeyName := os.Getenv(AllowedAuthProvidersEnvVarKeyName)
-	origAssumeRoleEnabledEnvVarKeyName := os.Getenv(AssumeRoleEnabledEnvVarKeyName)
 	origNewSTSCredentials := newSTSCredentials
 	t.Cleanup(func() {
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, origAllowedAuthProvidersEnvVarKeyName))
-		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, origAssumeRoleEnabledEnvVarKeyName))
 		newSTSCredentials = origNewSTSCredentials
 	})
 
 	t.Run("externalID is passed to the session", func(t *testing.T) {
-		originalExternalId := os.Getenv(GrafanaAssumeRoleExternalIdKeyName)
-		os.Setenv(GrafanaAssumeRoleExternalIdKeyName, "pretendExternalId")
 		newSTSCredentials = func(c client.ConfigProvider, roleARN string,
 			options ...func(*stscreds.AssumeRoleProvider)) *credentials.Credentials {
 			p := &stscreds.AssumeRoleProvider{
@@ -308,17 +308,20 @@ func TestNewSession_GrafanaAssumeRole(t *testing.T) {
 			return credentials.NewCredentials(p)
 		}
 
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "grafana_assume_role"))
-		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
-
 		cache := NewSessionCache()
-		_, err := cache.GetSession(SessionConfig{Settings: AWSDatasourceSettings{
-			AuthType:      AuthTypeGrafanaAssumeRole,
-			AssumeRoleARN: "test_arn",
-		}})
+		_, err := cache.GetSession(SessionConfig{
+			Settings: AWSDatasourceSettings{
+				AuthType:      AuthTypeGrafanaAssumeRole,
+				AssumeRoleARN: "test_arn",
+			},
+			AuthSettings: &AuthSettings{
+				AllowedAuthProviders: []string{"grafana_assume_role"},
+				ExternalID:           "pretendExternalId",
+				AssumeRoleEnabled:    true,
+			},
+		})
 
 		require.NoError(t, err)
-		os.Setenv(GrafanaAssumeRoleExternalIdKeyName, originalExternalId)
 	})
 
 	t.Run("roleARN is passed to the session", func(t *testing.T) {
@@ -334,14 +337,17 @@ func TestNewSession_GrafanaAssumeRole(t *testing.T) {
 			return credentials.NewCredentials(p)
 		}
 
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "grafana_assume_role"))
-		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
-
 		cache := NewSessionCache()
-		_, err := cache.GetSession(SessionConfig{Settings: AWSDatasourceSettings{
-			AuthType:      AuthTypeGrafanaAssumeRole,
-			AssumeRoleARN: "test_arn",
-		}})
+		_, err := cache.GetSession(SessionConfig{
+			Settings: AWSDatasourceSettings{
+				AuthType:      AuthTypeGrafanaAssumeRole,
+				AssumeRoleARN: "test_arn",
+			},
+			AuthSettings: &AuthSettings{
+				AllowedAuthProviders: []string{"grafana_assume_role"},
+				AssumeRoleEnabled:    true,
+			},
+		})
 
 		require.NoError(t, err)
 	})
@@ -377,11 +383,12 @@ func TestNewSession_EC2IAMRole(t *testing.T) {
 			Endpoint: "foo",
 		}
 
-		require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "ec2_iam_role"))
-		require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "true"))
-
 		cache := NewSessionCache()
-		sess, err := cache.GetSession(SessionConfig{Settings: settings})
+		sess, err := cache.GetSession(SessionConfig{Settings: settings,
+			AuthSettings: &AuthSettings{
+				AllowedAuthProviders: []string{"ec2_iam_role"},
+				AssumeRoleEnabled:    true,
+			}})
 		require.NoError(t, err)
 		require.NotNil(t, sess)
 
@@ -402,19 +409,18 @@ func TestNewSession_EC2IAMRole(t *testing.T) {
 	})
 }
 
-func unsetEnvironmentVariables() {
-	os.Unsetenv(AllowedAuthProvidersEnvVarKeyName)
-	os.Unsetenv(AssumeRoleEnabledEnvVarKeyName)
-	os.Unsetenv(SessionDurationEnvVarKeyName)
-	os.Unsetenv(GrafanaListMetricsPageLimit)
+func TestNewSession_EnvVarFallback(t *testing.T) {
+
 }
 
 func TestWithUserAgent(t *testing.T) {
-	defer unsetEnvironmentVariables()
-	require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
-	require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "false"))
 	cache := NewSessionCache()
-	sess, err := cache.GetSession(SessionConfig{UserAgentName: aws.String("Athena")})
+	sess, err := cache.GetSession(SessionConfig{UserAgentName: aws.String("Athena"),
+		AuthSettings: &AuthSettings{
+			AllowedAuthProviders: []string{"default"},
+			AssumeRoleEnabled:    false,
+		},
+	})
 	require.NoError(t, err)
 	require.NotNil(t, sess)
 	req := &request.Request{
@@ -427,12 +433,13 @@ func TestWithUserAgent(t *testing.T) {
 }
 
 func TestWithCustomHTTPClient(t *testing.T) {
-	defer unsetEnvironmentVariables()
-	require.NoError(t, os.Setenv(AllowedAuthProvidersEnvVarKeyName, "default"))
-	require.NoError(t, os.Setenv(AssumeRoleEnabledEnvVarKeyName, "false"))
 	cache := NewSessionCache()
 	sess, err := cache.GetSession(SessionConfig{
 		HTTPClient: &http.Client{Timeout: 123},
+		AuthSettings: &AuthSettings{
+			AllowedAuthProviders: []string{"default"},
+			AssumeRoleEnabled:    false,
+		},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, sess)

--- a/pkg/awsds/sessions_test.go
+++ b/pkg/awsds/sessions_test.go
@@ -113,7 +113,7 @@ func TestNewSession_AssumeRole(t *testing.T) {
 		settings := AWSDatasourceSettings{
 			AssumeRoleARN: roleARN,
 		}
-		var expectedDuration time.Duration = 1200000000000 //20 minutes in nanoseconds count
+		expectedDuration := 20 * time.Minute
 
 		t.Run("from config", func(t *testing.T) {
 			cache := NewSessionCache()


### PR DESCRIPTION
Previously, GetSessions would use the environment variables to get the grafana aws settings. This updates it to use settings passed in from the datasource and fallback to using the environment variables if they aren't set.

I also updated the changelog so that doesn't have to be a separate commit

for https://github.com/grafana/grafana/pull/81208