### PR TITLE
Fix warning message for failing to find the proxy env variable

### DIFF
--- a/pkg/awsds/authSettings.go
+++ b/pkg/awsds/authSettings.go
@@ -181,7 +181,7 @@ func ReadAuthSettingsFromEnvironmentVariables() *AuthSettings {
 
 	proxyEnabledString := os.Getenv(proxy.PluginSecureSocksProxyEnabled)
 	if len(proxyEnabledString) == 0 {
-		backend.Logger.Warn("environment variable missing. falling back to enable assume role", "var", AssumeRoleEnabledEnvVarKeyName)
+		backend.Logger.Warn("environment variable missing. falling back to proxy disabled", "var", proxy.PluginSecureSocksProxyEnabled)
 		proxyEnabledString = "false"
 	}
 


### PR DESCRIPTION
A copy paste mistake in the warning.
