### PR TITLE
Sessions: Use STS regional endpoint in assume role for opt-in regions

### DIFF
--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 )
@@ -219,6 +220,11 @@ func (sc *SessionCache) GetSession(c SessionConfig) (*session.Session, error) {
 			cfgs = append(cfgs, &aws.Config{Endpoint: aws.String(getSTSEndpoint(c.Settings.Endpoint))})
 		}
 
+		if isOptInRegion(c.Settings.Region) {
+			optInRegionCfg := &aws.Config{STSRegionalEndpoint: endpoints.RegionalSTSEndpoint}
+			cfgs = append(cfgs, optInRegionCfg)
+		}
+
 		sess, err := newSession(cfgs...)
 		if err != nil {
 			return nil, err
@@ -241,6 +247,11 @@ func (sc *SessionCache) GetSession(c SessionConfig) (*session.Session, error) {
 					}
 				}),
 			},
+		}
+
+		if isOptInRegion(c.Settings.Region) {
+			optInRegionCfg := &aws.Config{STSRegionalEndpoint: endpoints.RegionalSTSEndpoint}
+			cfgs = append(cfgs, optInRegionCfg)
 		}
 
 		if c.Settings.Region != "" {

--- a/pkg/awsds/sessions_test.go
+++ b/pkg/awsds/sessions_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/google/go-cmp/cmp"
@@ -219,6 +220,8 @@ func TestNewSession_AssumeRole(t *testing.T) {
 			sess := c.(*session.Session)
 			// Verify that we are using the well-known region
 			assert.Equal(t, "us-east-1", *sess.Config.Region)
+			// verify that we're using regional sts endpoint
+			assert.Equal(t, endpoints.RegionalSTSEndpoint, sess.Config.STSRegionalEndpoint)
 			return fakeNewSTSCredentials(c, roleARN, options...)
 		}
 		settings := AWSDatasourceSettings{


### PR DESCRIPTION
A [bug](https://github.com/grafana/support-escalations/issues/9155) was reported in cloudwatch when requesting resources and querying data for opt-in regions when the account is assuming a role. An error is returned from these endpoints `InvalidClientTokenId: The security token included in the request is invalid`

Opt-in regions are regions in AWS that have to be manually enabled in an AWS account. 

When requesting tokens with Amazon STS like we do when assuming role, we have to pass the `STSRegionalEndpoint` field with value 'regional' so that the returned tokens can be used in opt in regions. Otherwise global endpoint is used, which returns tokens that don't work with opt-in regions (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)


<img width="700" alt="Screenshot 2024-02-22 at 18 19 25" src="https://github.com/grafana/grafana-aws-sdk/assets/16140639/05cc7a87-0f9c-4e31-8a3c-e18c8aab4905">

[As of aws-sdk-go-v2](https://docs.aws.amazon.com/sdkref/latest/guide/feature-sts-regionalized-endpoints.html), STS service uses regional endpoints by default so this shouldn't be high impact. There's also the best practices outlined in the docs above for v1 that suggest to use regional sts endpoints. 

So far, we've suggested users set the  `AWS_STS_REGIONAL_ENDPOINTS=regional`  option in their env vars, which aws/aws-sdk would read. However, this isn't possible for hosted Grafana instances. 

Fixes https://github.com/grafana/support-escalations/issues/9155

To test this, you can use the assume role same account datasource from plugin provisioning, and query region eu-south-1 (opt in region that was manually enabled in the account). You should be getting "invalid token" before the fix, and query and resource requests with empty data after it and no errors