### PR TITLE
Move SigV4 config and middleware here

### DIFF
--- a/pkg/awsds/authSettings.go
+++ b/pkg/awsds/authSettings.go
@@ -28,6 +28,12 @@ const (
 	// ListMetricsPageLimitKeyName is the string literal for the cloudwatch list metrics page limit key name
 	ListMetricsPageLimitKeyName = "AWS_CW_LIST_METRICS_PAGE_LIMIT"
 
+	// SigV4AuthEnabledEnvVarKeyName is the string literal for the sigv4 auth enabled environment variable key name
+	SigV4AuthEnabledEnvVarKeyName = "AWS_SIGV4_AUTH_ENABLED"
+
+	// SigV4VerboseLoggingEnvVarKeyName is the string literal for the sigv4 verbose logging environment variable key name
+	SigV4VerboseLoggingEnvVarKeyName = "AWS_SIGV4_VERBOSE_LOGGING"
+
 	defaultAssumeRoleEnabled         = true
 	defaultListMetricsPageLimit      = 500
 	defaultSecureSocksDSProxyEnabled = false
@@ -192,4 +198,13 @@ func ReadAuthSettingsFromEnvironmentVariables() *AuthSettings {
 	}
 
 	return authSettings
+}
+
+// ReadSigV4Settings gets the SigV4 settings from the context if its available
+func ReadSigV4Settings(ctx context.Context) *SigV4Settings {
+	cfg := backend.GrafanaConfigFromContext(ctx)
+	return &SigV4Settings{
+		Enabled:        cfg.Get(SigV4AuthEnabledEnvVarKeyName) == "true",
+		VerboseLogging: cfg.Get(SigV4VerboseLoggingEnvVarKeyName) == "true",
+	}
 }

--- a/pkg/awsds/authSettings_test.go
+++ b/pkg/awsds/authSettings_test.go
@@ -155,6 +155,39 @@ func TestReadAuthSettings(t *testing.T) {
 	}
 }
 
+func TestReadSigV4Settings(t *testing.T) {
+	tcs := []struct {
+		name             string
+		cfg              *backend.GrafanaCfg
+		expectedSettings *SigV4Settings
+	}{
+		{
+			name:             "empty config map",
+			cfg:              backend.NewGrafanaCfg(make(map[string]string)),
+			expectedSettings: &SigV4Settings{},
+		},
+		{
+			name: "aws settings in config",
+			cfg: backend.NewGrafanaCfg(map[string]string{
+				SigV4AuthEnabledEnvVarKeyName:    "true",
+				SigV4VerboseLoggingEnvVarKeyName: "true",
+			}),
+			expectedSettings: &SigV4Settings{
+				Enabled:        true,
+				VerboseLogging: true,
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := backend.WithGrafanaConfig(context.Background(), tc.cfg)
+			settings := ReadSigV4Settings(ctx)
+
+			require.Equal(t, tc.expectedSettings, settings)
+		})
+	}
+}
+
 func unsetEnvironmentVariables() {
 	os.Unsetenv(AllowedAuthProvidersEnvVarKeyName)
 	os.Unsetenv(AssumeRoleEnabledEnvVarKeyName)

--- a/pkg/awsds/types.go
+++ b/pkg/awsds/types.go
@@ -29,6 +29,12 @@ type AuthSettings struct {
 	SecureSocksDSProxyEnabled bool
 }
 
+// SigV4Settings stores the settings for SigV4 authentication
+type SigV4Settings struct {
+	Enabled        bool
+	VerboseLogging bool
+}
+
 // QueryStatus represents the status of an async query
 type QueryStatus uint32
 

--- a/pkg/sigv4/sigv4_middleware.go
+++ b/pkg/sigv4/sigv4_middleware.go
@@ -1,0 +1,46 @@
+package sigv4
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+)
+
+// SigV4MiddlewareName the middleware name used by SigV4Middleware.
+const SigV4MiddlewareName = "sigv4"
+
+var newSigV4Func = New
+
+// SigV4Middleware applies AWS Signature Version 4 request signing for the outgoing request.
+func SigV4Middleware(verboseLogging bool) httpclient.Middleware {
+	return httpclient.NamedMiddlewareFunc(SigV4MiddlewareName, func(opts httpclient.Options, next http.RoundTripper) http.RoundTripper {
+		if opts.SigV4 == nil {
+			return next
+		}
+
+		conf := &Config{
+			Service:       opts.SigV4.Service,
+			AccessKey:     opts.SigV4.AccessKey,
+			SecretKey:     opts.SigV4.SecretKey,
+			Region:        opts.SigV4.Region,
+			AssumeRoleARN: opts.SigV4.AssumeRoleARN,
+			AuthType:      opts.SigV4.AuthType,
+			ExternalID:    opts.SigV4.ExternalID,
+			Profile:       opts.SigV4.Profile,
+		}
+
+		rt, err := newSigV4Func(conf, next, Opts{VerboseMode: verboseLogging})
+		if err != nil {
+			return invalidSigV4Config(err)
+		}
+
+		return rt
+	})
+}
+
+func invalidSigV4Config(err error) http.RoundTripper {
+	return httpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("invalid SigV4 configuration: %w", err)
+	})
+}

--- a/pkg/sigv4/sigv4_middleware_test.go
+++ b/pkg/sigv4/sigv4_middleware_test.go
@@ -1,0 +1,134 @@
+package sigv4
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/stretchr/testify/require"
+)
+
+type testContext struct {
+	callChain []string
+}
+
+func (c *testContext) createRoundTripper(name string) http.RoundTripper {
+	return httpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		c.callChain = append(c.callChain, name)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Request:    req,
+			Body:       io.NopCloser(bytes.NewBufferString("")),
+		}, nil
+	})
+}
+
+func TestSigV4Middleware(t *testing.T) {
+	t.Run("Without sigv4 options set should return next http.RoundTripper", func(t *testing.T) {
+		origSigV4Func := newSigV4Func
+		newSigV4Called := false
+		middlewareCalled := false
+		newSigV4Func = func(config *Config, next http.RoundTripper, opts ...Opts) (http.RoundTripper, error) {
+			newSigV4Called = true
+			return httpclient.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				middlewareCalled = true
+				return next.RoundTrip(r)
+			}), nil
+		}
+		t.Cleanup(func() {
+			newSigV4Func = origSigV4Func
+		})
+
+		ctx := &testContext{}
+		finalRoundTripper := ctx.createRoundTripper("finalrt")
+		mw := SigV4Middleware(false)
+		rt := mw.CreateMiddleware(httpclient.Options{}, finalRoundTripper)
+		require.NotNil(t, rt)
+		middlewareName, ok := mw.(httpclient.MiddlewareName)
+		require.True(t, ok)
+		require.Equal(t, SigV4MiddlewareName, middlewareName.MiddlewareName())
+
+		req, err := http.NewRequest(http.MethodGet, "http://", nil)
+		require.NoError(t, err)
+		res, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		if res.Body != nil {
+			require.NoError(t, res.Body.Close())
+		}
+		require.Len(t, ctx.callChain, 1)
+		require.ElementsMatch(t, []string{"finalrt"}, ctx.callChain)
+		require.False(t, newSigV4Called)
+		require.False(t, middlewareCalled)
+	})
+
+	t.Run("With sigv4 options set should call sigv4 http.RoundTripper", func(t *testing.T) {
+		origSigV4Func := newSigV4Func
+		newSigV4Called := false
+		middlewareCalled := false
+		newSigV4Func = func(config *Config, next http.RoundTripper, opts ...Opts) (http.RoundTripper, error) {
+			newSigV4Called = true
+			return httpclient.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				middlewareCalled = true
+				return next.RoundTrip(r)
+			}), nil
+		}
+		t.Cleanup(func() {
+			newSigV4Func = origSigV4Func
+		})
+
+		ctx := &testContext{}
+		finalRoundTripper := ctx.createRoundTripper("final")
+		mw := SigV4Middleware(false)
+		rt := mw.CreateMiddleware(httpclient.Options{SigV4: &httpclient.SigV4Config{}}, finalRoundTripper)
+		require.NotNil(t, rt)
+		middlewareName, ok := mw.(httpclient.MiddlewareName)
+		require.True(t, ok)
+		require.Equal(t, SigV4MiddlewareName, middlewareName.MiddlewareName())
+
+		req, err := http.NewRequest(http.MethodGet, "http://", nil)
+		require.NoError(t, err)
+		res, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		if res.Body != nil {
+			require.NoError(t, res.Body.Close())
+		}
+		require.Len(t, ctx.callChain, 1)
+		require.ElementsMatch(t, []string{"final"}, ctx.callChain)
+
+		require.True(t, newSigV4Called)
+		require.True(t, middlewareCalled)
+	})
+
+	t.Run("With sigv4 error returned", func(t *testing.T) {
+		origSigV4Func := newSigV4Func
+		newSigV4Func = func(config *Config, next http.RoundTripper, opts ...Opts) (http.RoundTripper, error) {
+			return nil, fmt.Errorf("problem")
+		}
+		t.Cleanup(func() {
+			newSigV4Func = origSigV4Func
+		})
+
+		ctx := &testContext{}
+		finalRoundTripper := ctx.createRoundTripper("final")
+		mw := SigV4Middleware(false)
+		rt := mw.CreateMiddleware(httpclient.Options{SigV4: &httpclient.SigV4Config{}}, finalRoundTripper)
+		require.NotNil(t, rt)
+		middlewareName, ok := mw.(httpclient.MiddlewareName)
+		require.True(t, ok)
+		require.Equal(t, SigV4MiddlewareName, middlewareName.MiddlewareName())
+
+		req, err := http.NewRequest(http.MethodGet, "http://", nil)
+		require.NoError(t, err)
+		// response is nil
+		// nolint:bodyclose
+		res, err := rt.RoundTrip(req)
+		require.Error(t, err)
+		require.Nil(t, res)
+		require.Empty(t, ctx.callChain)
+	})
+}


### PR DESCRIPTION
This PR does two things:

 - Adds a helper function to read SigV4 config from context.
 - Move the SigV4 middleware code from grafana/grafana here. The related PR is here: https://github.com/grafana/grafana/pull/84462