### PR TITLE
fix: aws sts assume role with custom endpoint

### DIFF
--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -305,5 +305,5 @@ func getSTSEndpoint(endpoint string) string {
 	if strings.Contains(endpoint, "us-gov-west-1") {
 		return "sts.us-gov-west-1.amazonaws.com"
 	}
-	return ""
+	return endpoint
 }

--- a/pkg/awsds/sessions_test.go
+++ b/pkg/awsds/sessions_test.go
@@ -297,8 +297,8 @@ func TestNewSession_AssumeRole(t *testing.T) {
 
 		require.NoError(t, err)
 		require.NotNil(t, sess)
-		// Verify that we use the endpoint from the settings
-		assert.Equal(t, settings.Endpoint, *sess.Config.Endpoint)
+		// Verify that we use the corrected fips endpoint, not the one from the settings
+		assert.Equal(t, "sts-fips.us-east-1.amazonaws.com", *sess.Config.Endpoint)
 	})
 
 	t.Run("Assume role is enabled with a non-fips endpoint", func(t *testing.T) {


### PR DESCRIPTION
PR #108 added some logic around AWS STS assume role, especially when specifying a FIPS endpoint. However, if the endpoint specified is not a FIPS endpoint, it breaks STS assume role. The was deployed from Grafana 10.4.0.

This PR fixes the issue and also adds another test case to prevent it from happening again.

Related issue with more information: https://github.com/grafana/grafana/issues/86496