### PR TITLE
Create GetSessionWithAuthSettings

### DIFF
--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -1,7 +1,6 @@
 package awsds
 
 import (
-	"context"
 	"crypto/sha256"
 	"fmt"
 	"net/http"
@@ -74,7 +73,7 @@ var newRemoteCredentials = func(sess *session.Session) *credentials.Credentials 
 	return credentials.NewCredentials(defaults.RemoteCredProvider(*sess.Config, sess.Handlers))
 }
 
-type GetSessionWithContextConfig struct {
+type GetSessionConfig struct {
 	Settings      AWSDatasourceSettings
 	HTTPClient    *http.Client
 	UserAgentName *string
@@ -107,7 +106,7 @@ func isOptInRegion(region string) bool {
 	return regions[region]
 }
 
-// Deprecated: use GetSessionWithContext instead
+// Deprecated: use GetSessionWithAuthSettings instead
 func (sc *SessionCache) GetSession(c SessionConfig) (*session.Session, error) {
 	if c.Settings.Region == "" && c.Settings.DefaultRegion != "" {
 		// DefaultRegion is deprecated, Region should be used instead
@@ -296,15 +295,13 @@ func (sc *SessionCache) GetSession(c SessionConfig) (*session.Session, error) {
 	return sess, nil
 }
 
-// When calling, be sure that the context passed is the datasource instance's context which contains auth settings
-func (sc *SessionCache) GetSessionWithContext(ctx context.Context, c GetSessionWithContextConfig) (*session.Session, error) {
-	authSettings, _ := ReadAuthSettingsFromContext(ctx)
-
+// AuthSettings can be grabed from the datasource instance's context with ReadSettingsFromContext
+func (sc *SessionCache) GetSessionWithAuthSettings(c GetSessionConfig, as AuthSettings) (*session.Session, error) {
 	return sc.GetSession(SessionConfig{
 		Settings:      c.Settings,
 		HTTPClient:    c.HTTPClient,
 		UserAgentName: c.UserAgentName,
-		AuthSettings:  authSettings,
+		AuthSettings:  &as,
 	})
 }
 

--- a/pkg/awsds/sessions_test.go
+++ b/pkg/awsds/sessions_test.go
@@ -1,7 +1,6 @@
 package awsds
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -20,8 +19,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -596,40 +593,20 @@ func TestWithCustomHTTPClient(t *testing.T) {
 	assert.Equal(t, time.Duration(123), sess.Config.HTTPClient.Timeout)
 }
 
-func TestGetSessionWithContext(t *testing.T) {
-	t.Run("it uses the passed in context for auth settings", func(t *testing.T) {
-		sessionCache := NewSessionCache()
-		sessionConfig := GetSessionWithContextConfig{
+func TestGetSessionWithAuthSettings(t *testing.T) {
+	t.Run("it uses the passed in for auth settings", func(t *testing.T) {
+		sessionConfig := GetSessionConfig{
 			Settings: AWSDatasourceSettings{
 				AuthType:  AuthTypeKeys,
 				AccessKey: "foo",
 				SecretKey: "bar",
 			},
 		}
-		dsInstanceContext := backend.WithGrafanaConfig(context.Background(), backend.NewGrafanaCfg(map[string]string{
-			AllowedAuthProvidersEnvVarKeyName:   "foo,bar",
-			AssumeRoleEnabledEnvVarKeyName:      "false",
-			GrafanaAssumeRoleExternalIdKeyName:  "mock_id",
-			ListMetricsPageLimitKeyName:         "50",
-			proxy.PluginSecureSocksProxyEnabled: "true",
-		}))
-
-		_, err := sessionCache.GetSessionWithContext(dsInstanceContext, sessionConfig)
-		require.EqualError(t, err, "attempting to use an auth type that is not allowed: \"keys\"")
-	})
-
-	t.Run("it uses the default auth settings if no auth settings are passed in the context", func(t *testing.T) {
-		sessionCache := NewSessionCache()
-		sessionConfig := GetSessionWithContextConfig{
-			Settings: AWSDatasourceSettings{
-				AuthType:  AuthTypeEC2IAMRole,
-				AccessKey: "foo",
-				SecretKey: "bar",
-			},
+		authSettings := AuthSettings{
+			AllowedAuthProviders: []string{"ec2_iam_role"},
 		}
-		dsInstanceContext := context.Background()
-
-		_, err := sessionCache.GetSessionWithContext(dsInstanceContext, sessionConfig)
-		require.EqualError(t, err, "attempting to use an auth type that is not allowed: \"ec2_iam_role\"")
+		sessionCache := NewSessionCache()
+		_, err := sessionCache.GetSessionWithAuthSettings(sessionConfig, authSettings)
+		require.EqualError(t, err, "attempting to use an auth type that is not allowed: \"keys\"")
 	})
 }


### PR DESCRIPTION
When working on https://github.com/grafana/timestream-datasource/pull/285 we noticed that in order to not rely on env variables we have to grab auth settings from the datasource instance's context and pass them along to GetSession.

However this is easy to forget/miss. This pr will create a new method for getting session which is passed in the datasource instance's context with auth settings and sets it as appropriate. 