### PR TITLE
SigV4: Update to not use env variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 - Add SigV4MiddlewareWithAuthSettings and deprecate SigV4Middleware [#150](https://github.com/grafana/grafana-aws-sdk/pull/150)
 
+[Breaking Change] `sigv4.New` now expects the auth settings to be passed in instead of fetched from environment variables.
+
 ## 0.27.1
 
 - add case sensitive metric name millisBehindLatest for KinesisAnalytics by @tristanburgess in https://github.com/grafana/grafana-aws-sdk/pull/148

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.28.0
+
+- Add SigV4MiddlewareWithAuthSettings and deprecate SigV4Middleware [#150](https://github.com/grafana/grafana-aws-sdk/pull/150)
+
 ## 0.27.1
 
 - add case sensitive metric name millisBehindLatest for KinesisAnalytics by @tristanburgess in https://github.com/grafana/grafana-aws-sdk/pull/148

--- a/pkg/awsds/authSettings.go
+++ b/pkg/awsds/authSettings.go
@@ -40,7 +40,7 @@ const (
 )
 
 // ReadAuthSettings gets the Grafana auth settings from the context if its available, the environment variables if not
-// This function is only for backwards compatibility, generally ReadAuthSettingsFromContext should be used instead
+// Deprecated: This function is only for backwards compatibility, generally ReadAuthSettingsFromContext should be used instead
 func ReadAuthSettings(ctx context.Context) *AuthSettings {
 	settings, exists := ReadAuthSettingsFromContext(ctx)
 	if !exists {

--- a/pkg/awsds/authSettings.go
+++ b/pkg/awsds/authSettings.go
@@ -40,6 +40,7 @@ const (
 )
 
 // ReadAuthSettings gets the Grafana auth settings from the context if its available, the environment variables if not
+// This function is only for backwards compatibility, generally ReadAuthSettingsFromContext should be used instead
 func ReadAuthSettings(ctx context.Context) *AuthSettings {
 	settings, exists := ReadAuthSettingsFromContext(ctx)
 	if !exists {

--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -295,7 +295,7 @@ func (sc *SessionCache) GetSession(c SessionConfig) (*session.Session, error) {
 	return sess, nil
 }
 
-// AuthSettings can be grabed from the datasource instance's context with ReadSettingsFromContext
+// AuthSettings can be grabed from the datasource instance's context with ReadAuthSettingsFromContext
 func (sc *SessionCache) GetSessionWithAuthSettings(c GetSessionConfig, as AuthSettings) (*session.Session, error) {
 	return sc.GetSession(SessionConfig{
 		Settings:      c.Settings,

--- a/pkg/sigv4/sigv4.go
+++ b/pkg/sigv4/sigv4.go
@@ -79,6 +79,7 @@ func (rt RoundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 
 // New instantiates a new signing middleware with an optional succeeding
 // middleware. The http.DefaultTransport will be used if nil
+// AuthSettings can be gotten from the datasource instance's context with awsds.ReadSettingsFromContext
 func New(cfg *Config, authSettings awsds.AuthSettings, next http.RoundTripper, opts ...Opts) (http.RoundTripper, error) {
 	var sigv4Opts Opts
 	switch len(opts) {

--- a/pkg/sigv4/sigv4.go
+++ b/pkg/sigv4/sigv4.go
@@ -79,7 +79,7 @@ func (rt RoundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 
 // New instantiates a new signing middleware with an optional succeeding
 // middleware. The http.DefaultTransport will be used if nil
-// AuthSettings can be gotten from the datasource instance's context with awsds.ReadSettingsFromContext
+// AuthSettings can be gotten from the datasource instance's context with awsds.ReadAuthSettingsFromContext
 func New(cfg *Config, authSettings awsds.AuthSettings, next http.RoundTripper, opts ...Opts) (http.RoundTripper, error) {
 	var sigv4Opts Opts
 	switch len(opts) {

--- a/pkg/sigv4/sigv4.go
+++ b/pkg/sigv4/sigv4.go
@@ -51,8 +51,6 @@ type Config struct {
 	AssumeRoleARN string
 	ExternalID    string
 	Region        string
-
-	AuthSettings awsds.AuthSettings
 }
 
 type Opts struct {
@@ -81,7 +79,7 @@ func (rt RoundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 
 // New instantiates a new signing middleware with an optional succeeding
 // middleware. The http.DefaultTransport will be used if nil
-func New(cfg *Config, next http.RoundTripper, opts ...Opts) (http.RoundTripper, error) {
+func New(cfg *Config, authSettings awsds.AuthSettings, next http.RoundTripper, opts ...Opts) (http.RoundTripper, error) {
 	var sigv4Opts Opts
 	switch len(opts) {
 	case 0:
@@ -109,7 +107,7 @@ func New(cfg *Config, next http.RoundTripper, opts ...Opts) (http.RoundTripper, 
 			signer = cached
 		} else {
 			var err error
-			signer, err = createSigner(cfg, sigv4Opts.VerboseMode)
+			signer, err = createSigner(cfg, authSettings, sigv4Opts.VerboseMode)
 			if err != nil {
 				return nil, err
 			}
@@ -183,14 +181,14 @@ func cachedSigner(cfg *Config) (*v4.Signer, bool) {
 	return nil, false
 }
 
-func createSigner(cfg *Config, verboseMode bool) (*v4.Signer, error) {
+func createSigner(cfg *Config, authSettings awsds.AuthSettings, verboseMode bool) (*v4.Signer, error) {
 	authType, err := awsds.ToAuthType(cfg.AuthType)
 	if err != nil {
 		return nil, err
 	}
 
 	authTypeAllowed := false
-	for _, provider := range cfg.AuthSettings.AllowedAuthProviders {
+	for _, provider := range authSettings.AllowedAuthProviders {
 		if provider == authType.String() {
 			authTypeAllowed = true
 			break
@@ -201,7 +199,7 @@ func createSigner(cfg *Config, verboseMode bool) (*v4.Signer, error) {
 		return nil, fmt.Errorf("attempting to use an auth type for SigV4 that is not allowed: %q", authType.String())
 	}
 
-	if cfg.AssumeRoleARN != "" && !cfg.AuthSettings.AssumeRoleEnabled {
+	if cfg.AssumeRoleARN != "" && !authSettings.AssumeRoleEnabled {
 		return nil, fmt.Errorf("attempting to use assume role (ARN) for SigV4 which is not enabled")
 	}
 

--- a/pkg/sigv4/sigv4.go
+++ b/pkg/sigv4/sigv4.go
@@ -51,6 +51,8 @@ type Config struct {
 	AssumeRoleARN string
 	ExternalID    string
 	Region        string
+
+	AuthSettings awsds.AuthSettings
 }
 
 type Opts struct {
@@ -187,9 +189,8 @@ func createSigner(cfg *Config, verboseMode bool) (*v4.Signer, error) {
 		return nil, err
 	}
 
-	authSettings := awsds.ReadAuthSettingsFromEnvironmentVariables()
 	authTypeAllowed := false
-	for _, provider := range authSettings.AllowedAuthProviders {
+	for _, provider := range cfg.AuthSettings.AllowedAuthProviders {
 		if provider == authType.String() {
 			authTypeAllowed = true
 			break
@@ -200,7 +201,7 @@ func createSigner(cfg *Config, verboseMode bool) (*v4.Signer, error) {
 		return nil, fmt.Errorf("attempting to use an auth type for SigV4 that is not allowed: %q", authType.String())
 	}
 
-	if cfg.AssumeRoleARN != "" && !authSettings.AssumeRoleEnabled {
+	if cfg.AssumeRoleARN != "" && !cfg.AuthSettings.AssumeRoleEnabled {
 		return nil, fmt.Errorf("attempting to use assume role (ARN) for SigV4 which is not enabled")
 	}
 

--- a/pkg/sigv4/sigv4_middleware.go
+++ b/pkg/sigv4/sigv4_middleware.go
@@ -14,6 +14,7 @@ const SigV4MiddlewareName = "sigv4"
 var newSigV4Func = New
 
 // SigV4MiddlewareWithAuthSettings applies AWS Signature Version 4 request signing for the outgoing request.
+// AuthSettings can be gotten from the datasource instance's context with awsds.ReadSettingsFromContext
 func SigV4MiddlewareWithAuthSettings(verboseLogging bool, authSettings awsds.AuthSettings) httpclient.Middleware {
 	return httpclient.NamedMiddlewareFunc(SigV4MiddlewareName, func(opts httpclient.Options, next http.RoundTripper) http.RoundTripper {
 		if opts.SigV4 == nil {

--- a/pkg/sigv4/sigv4_middleware.go
+++ b/pkg/sigv4/sigv4_middleware.go
@@ -30,10 +30,9 @@ func SigV4MiddlewareWithAuthSettings(verboseLogging bool, authSettings awsds.Aut
 			AuthType:      opts.SigV4.AuthType,
 			ExternalID:    opts.SigV4.ExternalID,
 			Profile:       opts.SigV4.Profile,
-			AuthSettings:  authSettings,
 		}
 
-		rt, err := newSigV4Func(conf, next, Opts{VerboseMode: verboseLogging})
+		rt, err := newSigV4Func(conf, authSettings, next, Opts{VerboseMode: verboseLogging})
 		if err != nil {
 			return invalidSigV4Config(err)
 		}

--- a/pkg/sigv4/sigv4_middleware.go
+++ b/pkg/sigv4/sigv4_middleware.go
@@ -14,7 +14,7 @@ const SigV4MiddlewareName = "sigv4"
 var newSigV4Func = New
 
 // SigV4MiddlewareWithAuthSettings applies AWS Signature Version 4 request signing for the outgoing request.
-// AuthSettings can be gotten from the datasource instance's context with awsds.ReadSettingsFromContext
+// AuthSettings can be gotten from the datasource instance's context with awsds.ReadAuthSettingsFromContext
 func SigV4MiddlewareWithAuthSettings(verboseLogging bool, authSettings awsds.AuthSettings) httpclient.Middleware {
 	return httpclient.NamedMiddlewareFunc(SigV4MiddlewareName, func(opts httpclient.Options, next http.RoundTripper) http.RoundTripper {
 		if opts.SigV4 == nil {

--- a/pkg/sigv4/sigv4_middleware_test.go
+++ b/pkg/sigv4/sigv4_middleware_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/stretchr/testify/require"
 )
@@ -31,7 +32,7 @@ func TestSigV4Middleware(t *testing.T) {
 		origSigV4Func := newSigV4Func
 		newSigV4Called := false
 		middlewareCalled := false
-		newSigV4Func = func(config *Config, next http.RoundTripper, opts ...Opts) (http.RoundTripper, error) {
+		newSigV4Func = func(config *Config, authSettings awsds.AuthSettings, next http.RoundTripper, opts ...Opts) (http.RoundTripper, error) {
 			newSigV4Called = true
 			return httpclient.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 				middlewareCalled = true
@@ -69,7 +70,7 @@ func TestSigV4Middleware(t *testing.T) {
 		origSigV4Func := newSigV4Func
 		newSigV4Called := false
 		middlewareCalled := false
-		newSigV4Func = func(config *Config, next http.RoundTripper, opts ...Opts) (http.RoundTripper, error) {
+		newSigV4Func = func(config *Config, authSettings awsds.AuthSettings, next http.RoundTripper, opts ...Opts) (http.RoundTripper, error) {
 			newSigV4Called = true
 			return httpclient.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 				middlewareCalled = true
@@ -106,7 +107,7 @@ func TestSigV4Middleware(t *testing.T) {
 
 	t.Run("With sigv4 error returned", func(t *testing.T) {
 		origSigV4Func := newSigV4Func
-		newSigV4Func = func(config *Config, next http.RoundTripper, opts ...Opts) (http.RoundTripper, error) {
+		newSigV4Func = func(config *Config, authSettings awsds.AuthSettings, next http.RoundTripper, opts ...Opts) (http.RoundTripper, error) {
 			return nil, fmt.Errorf("problem")
 		}
 		t.Cleanup(func() {

--- a/pkg/sigv4/sigv4_test.go
+++ b/pkg/sigv4/sigv4_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 
@@ -17,14 +18,14 @@ import (
 
 func TestNew(t *testing.T) {
 	t.Run("Can't create new middleware without valid auth type", func(t *testing.T) {
-		rt, err := New(&Config{}, nil)
+		rt, err := New(&Config{}, awsds.AuthSettings{}, nil)
 		require.Error(t, err)
 		require.Nil(t, rt)
 
 	})
 	t.Run("Can create new middleware with any valid auth type", func(t *testing.T) {
 		for _, authType := range []string{"credentials", "sharedCreds", "keys", "default", "ec2_iam_role", "arn"} {
-			rt, err := New(&Config{AuthType: authType}, nil)
+			rt, err := New(&Config{AuthType: authType}, awsds.AuthSettings{}, nil)
 
 			require.NoError(t, err)
 			require.NotNil(t, rt)
@@ -33,7 +34,7 @@ func TestNew(t *testing.T) {
 
 	t.Run("Can sign a request", func(t *testing.T) {
 		cfg := &Config{AuthType: "default"}
-		rt, err := New(cfg, &fakeTransport{})
+		rt, err := New(cfg, awsds.AuthSettings{}, &fakeTransport{})
 		require.NoError(t, err)
 		require.NotNil(t, rt)
 		r, err := http.NewRequest("GET", "http://grafana.sigv4.test", nil)
@@ -63,7 +64,7 @@ func TestNew(t *testing.T) {
 
 	t.Run("Can sign a request with extra headers which are not signed", func(t *testing.T) {
 		cfg := &Config{AuthType: "default"}
-		rt, err := New(cfg, &fakeTransport{})
+		rt, err := New(cfg, awsds.AuthSettings{}, &fakeTransport{})
 		require.NoError(t, err)
 		require.NotNil(t, rt)
 		r, err := http.NewRequest("GET", "http://grafana.sigv4.test", nil)
@@ -96,7 +97,7 @@ func TestNew(t *testing.T) {
 
 	t.Run("Signed request overwrites existing Authorization header", func(t *testing.T) {
 		cfg := &Config{AuthType: "default"}
-		rt, err := New(cfg, &fakeTransport{})
+		rt, err := New(cfg, awsds.AuthSettings{}, &fakeTransport{})
 		require.NoError(t, err)
 		require.NotNil(t, rt)
 		r, err := http.NewRequest("GET", "http://grafana.sigv4.test", nil)
@@ -122,7 +123,7 @@ func TestNew(t *testing.T) {
 
 	t.Run("Can't sign a request without valid credentials", func(t *testing.T) {
 		cfg := &Config{AuthType: "ec2_iam_role"}
-		rt, err := New(cfg, &fakeTransport{})
+		rt, err := New(cfg, awsds.AuthSettings{}, &fakeTransport{})
 		require.NoError(t, err)
 		require.NotNil(t, rt)
 		r, err := http.NewRequest("GET", "http://grafana.sigv4.test", nil)
@@ -150,7 +151,7 @@ func TestNew(t *testing.T) {
 		fakeLogger := &fakeLogger{}
 		backend.Logger = fakeLogger
 
-		rt, err := New(cfg, &fakeTransport{}, Opts{VerboseMode: true})
+		rt, err := New(cfg, awsds.AuthSettings{}, &fakeTransport{}, Opts{VerboseMode: true})
 		require.NoError(t, err)
 		require.NotNil(t, rt)
 		r, err := http.NewRequest("GET", "http://grafana.sigv4.test", nil)
@@ -182,7 +183,7 @@ func TestNew(t *testing.T) {
 		fakeLogger := &fakeLogger{}
 		backend.Logger = fakeLogger
 
-		rt, err := New(cfg, &fakeTransport{}, Opts{VerboseMode: false})
+		rt, err := New(cfg, awsds.AuthSettings{}, &fakeTransport{}, Opts{VerboseMode: false})
 		require.NoError(t, err)
 		require.NotNil(t, rt)
 		r, err := http.NewRequest("GET", "http://grafana.sigv4.test", nil)


### PR DESCRIPTION
This is to support not using environment variables in prometheus-amazon

Technically, this is a breaking change on sigv4.New. Also technically, this is an experimental library so we're allowed to break things, and it's not going to compile, so users (if there are any that aren't us) will definitely notice.

We should also update grafana with the new versions of the deprecated functions once this goes in.