### PR TITLE
Support errorsource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.29.0
+* Support errorsource by @njvrzm in https://github.com/grafana/grafana-aws-sdk/pull/155
+* Add DatabaseCapacityUsageCountedForEvictPercentage for AWS/ElastiCache by @andriikushch in https://github.com/grafana/grafana-aws-sdk/pull/152
+* Add some missing metrics to AWS/ElastiCache by @andriikushch in https://github.com/grafana/grafana-aws-sdk/pull/153
+
 ## 0.28.0
 
 - Add SigV4MiddlewareWithAuthSettings and deprecate SigV4Middleware [#150](https://github.com/grafana/grafana-aws-sdk/pull/150)

--- a/pkg/awsds/asyncDatasource.go
+++ b/pkg/awsds/asyncDatasource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 	"github.com/grafana/sqlds/v3"
 )
 
@@ -117,10 +118,11 @@ func (ds *AsyncAWSDatasource) QueryData(ctx context.Context, req *backend.QueryD
 			var frames data.Frames
 			var err error
 			frames, err = ds.handleAsyncQuery(ctx, query, req.PluginContext.DataSourceInstanceSettings.UID)
-			response.Set(query.RefID, backend.DataResponse{
-				Frames: frames,
-				Error:  err,
-			})
+			if err != nil {
+				response.Set(query.RefID, errorsource.Response(err))
+			} else {
+				response.Set(query.RefID, backend.DataResponse{Frames: frames})
+			}
 
 			wg.Done()
 		}(q)


### PR DESCRIPTION
This supports adding errorsource to clients of the sdk. One example here: https://github.com/grafana/athena-datasource/pull/344.

Also prepares for v0.29.0 release.