### PR TITLE
Add expected casing for AWS/Kafka TCPConnections

### DIFF
--- a/pkg/cloudWatchConsts/metrics.go
+++ b/pkg/cloudWatchConsts/metrics.go
@@ -1668,6 +1668,7 @@ var NamespaceMetricsMap = map[string][]string{
 		"SumOffsetLag",
 		"SwapFree",
 		"SwapUsed",
+		"TCPConnections",
 		"TcpConnections",
 		"TrafficBytes",
 		"TrafficShaping",


### PR DESCRIPTION
This PR adds what looks to be the proper casing for TCP Connections for AWS/Kafka. I added it vs replacing it because I'm not quite sure what it would mean to remove the other one for the data source.

The AWS documentation shows the value we use today, 
![image](https://github.com/user-attachments/assets/7919affd-16d2-4fbc-83fa-5ca5b92a84fd)
https://docs.aws.amazon.com/msk/latest/developerguide/metrics-details.html

But when looking at this metric within our own AWS systems it appears to be `TCPConnections`,
![image](https://github.com/user-attachments/assets/74652fe2-af38-4d2d-8eca-4a90670834c2) 
and because metrics are case sensitive it causes some problems with using the metric with the current casing.