### PR TITLE
For the backward compatibility revert metric name deletion

### DIFF
--- a/pkg/cloudWatchConsts/metrics.go
+++ b/pkg/cloudWatchConsts/metrics.go
@@ -3006,6 +3006,7 @@ var NamespaceMetricsMap = map[string][]string{
 		"instance_memory_limit",
 		"instance_memory_reserved_capacity",
 		"instance_memory_utilization",
+		"instance_memory_utliization",
 		"instance_memory_working_set",
 		"instance_network_total_bytes",
 		"instance_number_of_running_tasks",


### PR DESCRIPTION
Revert metric name deletion from 

- https://github.com/grafana/grafana-aws-sdk/pull/161/files