### PR TITLE
Mark downstream errors in sessions.go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 ## 0.31.1
 
-- Mark auth errors as downstream in sessions.go
+- Mark dowstream errors in sessions.go in https://github.com/grafana/grafana-aws-sdk/pull/169
 
 ## 0.31.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 All notable changes to this project will be documented in this file.
+## 0.31.1
+
+- Mark auth errors as downstream in sessions.go
 
 ## 0.31.0
 


### PR DESCRIPTION
Some auth/downstream errors have been logged for athena coming from sessions.go when querying. (see panel [here](https://ops.grafana-ops.net/d/cdsqp9biempdscss/292bed9e-d925-52ae-ae45-d71b67b7b233?var-datasource=athena-datasource&var-cluster=$__all&orgId=1&viewPanel=19&from=now-7d&to=now&editPanel=19)) so marking them as downstream instead of plugin errors. 
<img width="400" alt="Screenshot 2024-09-17 at 11 26 37" src="https://github.com/user-attachments/assets/c0abb79c-18ef-4f9b-9d62-16971babee57">
