### PR TITLE
Add new SQS FIFO metrics

### DIFF
--- a/pkg/cloudWatchConsts/metrics.go
+++ b/pkg/cloudWatchConsts/metrics.go
@@ -2786,9 +2786,11 @@ var NamespaceMetricsMap = map[string][]string{
 	},
 	"AWS/SQS": {
 		"ApproximateAgeOfOldestMessage",
+		"ApproximateNumberOfGroupsWithInflightMessages",
 		"ApproximateNumberOfMessagesDelayed",
 		"ApproximateNumberOfMessagesNotVisible",
 		"ApproximateNumberOfMessagesVisible",
+		"NumberOfDeduplicatedSentMessages",
 		"NumberOfEmptyReceives",
 		"NumberOfMessagesDeleted",
 		"NumberOfMessagesReceived",


### PR DESCRIPTION
Add new metrics from https://aws.amazon.com/about-aws/whats-new/2024/07/amazon-sqs-cloudwatch-metrics-fifo-queues/, on BQuant request
