### PR TITLE
Add missing LegacyModelInvocations AWS bedrock metric

### DIFF
--- a/pkg/cloudWatchConsts/metrics.go
+++ b/pkg/cloudWatchConsts/metrics.go
@@ -319,6 +319,7 @@ var NamespaceMetricsMap = map[string][]string{
 		"InvocationServerErrors",
 		"InvocationThrottles",
 		"Invocations",
+		"LegacyModelInvocations",
 		"OutputImageCount",
 		"OutputTokenCount",
 	},


### PR DESCRIPTION
The AWS doc has `LegacyModelInvocations` metric which is missing from the mappings:

* https://docs.aws.amazon.com/bedrock/latest/userguide/monitoring.html#runtime-cloudwatch-metrics

> Metric Name            | Unit        | Description
> ---------------------- | ----------- | --
> LegacyModelInvocations | SampleCount | Number of invocations using [Legacy](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_FoundationModelLifecycle.html) models