### PR TITLE
Fix: use alternate STS endpoint for STS interaction if given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.33.1
+- Fix: use alternate STS endpoint for STS interaction if given by @njvrzm in https://github.com/grafana/grafana-aws-sdk/pull/214
+
 ## 0.33.0
 
 - Update CodeBuild metrics and dimensions by @hectorruiz-it in https://github.com/grafana/grafana-aws-sdk/pull/209

--- a/pkg/awsauth/auth.go
+++ b/pkg/awsauth/auth.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"strings"
 )
 
 type ConfigProvider interface {
@@ -72,4 +73,8 @@ func (rcp *awsConfigProvider) GetConfig(ctx context.Context, authSettings Settin
 
 	rcp.cache[key] = cfg
 	return cfg, nil
+}
+
+func isStsEndpoint(ep *string) bool {
+	return ep != nil && (strings.HasPrefix(*ep, "sts.") || strings.HasPrefix(*ep, "sts-fips."))
 }

--- a/pkg/awsauth/settings.go
+++ b/pkg/awsauth/settings.go
@@ -127,6 +127,9 @@ func (s Settings) WithAssumeRole(cfg aws.Config, client AWSAPIClient) LoadOption
 	cache := client.NewCredentialsCache(provider)
 	return func(options *config.LoadOptions) error {
 		options.Credentials = cache
+		if isStsEndpoint(cfg.BaseEndpoint) {
+			options.BaseEndpoint = ""
+		}
 		return nil
 	}
 }

--- a/pkg/awsauth/test_utils.go
+++ b/pkg/awsauth/test_utils.go
@@ -35,7 +35,8 @@ func (m *mockAWSAPIClient) NewStaticCredentialsProvider(key, secret, session str
 	return credentials.NewStaticCredentialsProvider(key, secret, session)
 }
 
-func (m *mockAWSAPIClient) NewSTSClientFromConfig(_ aws.Config) stscreds.AssumeRoleAPIClient {
+func (m *mockAWSAPIClient) NewSTSClientFromConfig(cfg aws.Config) stscreds.AssumeRoleAPIClient {
+	m.assumeRoleClient.stsConfig = cfg
 	return m.assumeRoleClient
 }
 
@@ -54,6 +55,7 @@ func (m *mockAWSAPIClient) NewEC2RoleCreds() aws.CredentialsProvider {
 
 type mockAssumeRoleAPIClient struct {
 	mock.Mock
+	stsConfig aws.Config
 }
 
 func (m *mockAssumeRoleAPIClient) AssumeRole(_ context.Context, params *sts.AssumeRoleInput, _ ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {


### PR DESCRIPTION
This fixes a regression from the fix in #136: if the datasource config gives an endpoint and that endpoint is for STS, we need to use that endpoint for STS interaction but not afterwards.

This also fixes a unit test from the previous release that was failing, and prepares the next release.