### PR TITLE
Use DefaultClient if given nil HTTPClient

### DIFF
--- a/pkg/awsauth/settings.go
+++ b/pkg/awsauth/settings.go
@@ -181,6 +181,9 @@ func (s Settings) WithHTTPClient() LoadOptionsFunc {
 		if s.HTTPClient != nil {
 			options.HTTPClient = s.HTTPClient
 		}
+		if options.HTTPClient == nil {
+			options.HTTPClient = http.DefaultClient
+		}
 		if s.ProxyOptions != nil {
 			if client, ok := options.HTTPClient.(*http.Client); ok {
 				if client.Transport == nil {


### PR DESCRIPTION
SecureSocksProxy is currently failing with the new v2 auth; the log doesn't contain enough details to be sure but I believe it's because the HTTPClient is coming in nil.