### PR TITLE
Fix: clone default transport instead of using it for PDC

### DIFF
--- a/pkg/awsauth/settings.go
+++ b/pkg/awsauth/settings.go
@@ -187,7 +187,7 @@ func (s Settings) WithHTTPClient() LoadOptionsFunc {
 		if s.ProxyOptions != nil {
 			if client, ok := options.HTTPClient.(*http.Client); ok {
 				if client.Transport == nil {
-					client.Transport = http.DefaultTransport
+					client.Transport = http.DefaultTransport.(*http.Transport).Clone()
 				}
 				if transport, ok := client.Transport.(*http.Transport); ok {
 					err := proxy.New(s.ProxyOptions).ConfigureSecureSocksHTTPProxy(transport)


### PR DESCRIPTION
With the current code when PDC is applied it applies to the default transport, which causes problems in mutli-tenant mode.