### PR TITLE
Add support for multitenant temporary credentials to v1 path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.38.0
+
+- Add multitenant temporary credentials support to the sdk v1 path
+
 ## 0.37.0
+
 - Fix: clone default transport instead of using it for PDC by @njvrzm in [#229](https://github.com/grafana/grafana-aws-sdk/pull/229)
 - Fix paths for multitenant [#228](https://github.com/grafana/grafana-aws-sdk/pull/228)
 
 ## 0.36.0
+
 - Add dimensions to msk connect and pipe metric namespaces by @rrhodes in [#223](https://github.com/grafana/grafana-aws-sdk/pull/223)
 - Fix: Use DefaultClient in awsauth if given nil HTTPClient by @njvrzm in [#226](https://github.com/grafana/grafana-aws-sdk/pull/226)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## 0.38.0
 
-- Add multitenant temporary credentials support to the sdk v1 path
+- Add support for multitenant temporary credentials to v1 path by @iwysiu in [#231](https://github.com/grafana/grafana-aws-sdk/pull/231)
 
 ## 0.37.0
 

--- a/pkg/awsds/authSettings.go
+++ b/pkg/awsds/authSettings.go
@@ -60,8 +60,8 @@ func defaultAuthSettings() *AuthSettings {
 		AssumeRoleEnabled:          defaultAssumeRoleEnabled,
 		SessionDuration:            &stscreds.DefaultDuration,
 		ListMetricsPageLimit:       defaultListMetricsPageLimit,
-		SecureSocksDSProxyEnabled:  defaultSecureSocksDSProxyEnabled,
 		MultiTenantTempCredentials: defaultMultiTenantTempCredentials,
+		SecureSocksDSProxyEnabled:  defaultSecureSocksDSProxyEnabled,
 	}
 }
 

--- a/pkg/awsds/authSettings.go
+++ b/pkg/awsds/authSettings.go
@@ -34,9 +34,13 @@ const (
 	// SigV4VerboseLoggingEnvVarKeyName is the string literal for the sigv4 verbose logging environment variable key name
 	SigV4VerboseLoggingEnvVarKeyName = "AWS_SIGV4_VERBOSE_LOGGING"
 
-	defaultAssumeRoleEnabled         = true
-	defaultListMetricsPageLimit      = 500
-	defaultSecureSocksDSProxyEnabled = false
+	// FlagMultiTenantTempCredentials is the flag for whether temporary credentials is running multitenant
+	FlagMultiTenantTempCredentials = "multiTenantTempCredentials"
+
+	defaultAssumeRoleEnabled          = true
+	defaultListMetricsPageLimit       = 500
+	defaultSecureSocksDSProxyEnabled  = false
+	defaultMultiTenantTempCredentials = false
 )
 
 // ReadAuthSettings gets the Grafana auth settings from the context if its available, the environment variables if not
@@ -52,11 +56,12 @@ func ReadAuthSettings(ctx context.Context) *AuthSettings {
 
 func defaultAuthSettings() *AuthSettings {
 	return &AuthSettings{
-		AllowedAuthProviders:      []string{"default", "keys", "credentials"},
-		AssumeRoleEnabled:         defaultAssumeRoleEnabled,
-		SessionDuration:           &stscreds.DefaultDuration,
-		ListMetricsPageLimit:      defaultListMetricsPageLimit,
-		SecureSocksDSProxyEnabled: defaultSecureSocksDSProxyEnabled,
+		AllowedAuthProviders:       []string{"default", "keys", "credentials"},
+		AssumeRoleEnabled:          defaultAssumeRoleEnabled,
+		SessionDuration:            &stscreds.DefaultDuration,
+		ListMetricsPageLimit:       defaultListMetricsPageLimit,
+		SecureSocksDSProxyEnabled:  defaultSecureSocksDSProxyEnabled,
+		MultiTenantTempCredentials: defaultMultiTenantTempCredentials,
 	}
 }
 
@@ -128,6 +133,7 @@ func ReadAuthSettingsFromContext(ctx context.Context) (*AuthSettings, bool) {
 		hasSettings = true
 	}
 
+	settings.MultiTenantTempCredentials = cfg.FeatureToggles().IsEnabled(FlagMultiTenantTempCredentials)
 	return settings, hasSettings
 }
 

--- a/pkg/awsds/types.go
+++ b/pkg/awsds/types.go
@@ -19,15 +19,15 @@ type AmazonSessionProvider func(region string, s AWSDatasourceSettings) (*sessio
 
 // AuthSettings stores the AWS settings from Grafana
 type AuthSettings struct {
-	AllowedAuthProviders []string
-	AssumeRoleEnabled    bool
-	SessionDuration      *time.Duration
-	ExternalID           string
-	ListMetricsPageLimit int
+	AllowedAuthProviders       []string
+	AssumeRoleEnabled          bool
+	SessionDuration            *time.Duration
+	ExternalID                 string
+	ListMetricsPageLimit       int
+	MultiTenantTempCredentials bool
 
 	// necessary for a work around until https://github.com/grafana/grafana/issues/39089 is implemented
-	SecureSocksDSProxyEnabled  bool
-	MultiTenantTempCredentials bool
+	SecureSocksDSProxyEnabled bool
 }
 
 // SigV4Settings stores the settings for SigV4 authentication

--- a/pkg/awsds/types.go
+++ b/pkg/awsds/types.go
@@ -26,7 +26,8 @@ type AuthSettings struct {
 	ListMetricsPageLimit int
 
 	// necessary for a work around until https://github.com/grafana/grafana/issues/39089 is implemented
-	SecureSocksDSProxyEnabled bool
+	SecureSocksDSProxyEnabled  bool
+	MultiTenantTempCredentials bool
 }
 
 // SigV4Settings stores the settings for SigV4 authentication
@@ -54,7 +55,7 @@ const (
 	QueryFailedUser
 )
 
-// QueryExecutionError error type can be returned from datasource's Execute or QueryStatus methods 
+// QueryExecutionError error type can be returned from datasource's Execute or QueryStatus methods
 // this will mark the downstream cause in errorResponse.Status
 type QueryExecutionError struct {
 	Err   error


### PR DESCRIPTION
Updates the aws-sdk-v1 path to get the access and secret key for multitenant temp creds and prepares the release.