### PR TITLE
Support passing session token with v2 auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-## 0.38.1
+## 0.38.2
+- Support passing session token with v2 auth by @njvrzm in [#234](https://github.com/grafana/grafana-aws-sdk/pull/234)
+- Add vault tokens and zizmor config by @katebrenner in [#236](https://github.com/grafana/grafana-aws-sdk/pull/236)
+- Update network firewall metrics by @tristanburgess in [#237](https://github.com/grafana/grafana-aws-sdk/pull/237)
 
-- Cleanup github actions files in [#233](https://github.com/grafana/grafana-aws-sdk/pull/233)
+## 0.38.1
+- Cleanup github actions files by @iwysiu in [#233](https://github.com/grafana/grafana-aws-sdk/pull/233)
 - Fix check for multitenant temporary credentials by @iwysiu in [#235](https://github.com/grafana/grafana-aws-sdk/pull/235)
 
 ## 0.38.0

--- a/pkg/awsauth/auth_test.go
+++ b/pkg/awsauth/auth_test.go
@@ -48,6 +48,9 @@ func (tc testCase) Run(t *testing.T) {
 		require.NoError(t, err)
 		tc.assertConfig(t, cfg)
 		creds, _ := cfg.Credentials.Retrieve(ctx)
+		if tc.authSettings.GetAuthType() == AuthTypeKeys && tc.authSettings.SessionToken != "" {
+			assert.Equal(t, tc.authSettings.SessionToken, creds.SessionToken)
+		}
 		accessKey, secret := tc.getExpectedKeyAndSecret(t)
 		assert.Equal(t, accessKey, creds.AccessKeyID)
 		assert.Equal(t, secret, creds.SecretAccessKey)
@@ -145,6 +148,16 @@ func TestGetAWSConfig_Keys(t *testing.T) {
 				AccessKey:      "ubiquitous",
 				SecretKey:      "malevolent",
 				Region:         "ap-south-1",
+			},
+		},
+		{
+			name: "static credentials with session token",
+			authSettings: Settings{
+				LegacyAuthType: awsds.AuthTypeKeys,
+				AccessKey:      "ubiquitous",
+				SecretKey:      "malevolent",
+				Region:         "ap-south-1",
+				SessionToken:   "alphabet",
 			},
 		},
 	}.runAll(t)

--- a/pkg/awsauth/settings.go
+++ b/pkg/awsauth/settings.go
@@ -42,6 +42,7 @@ type Settings struct {
 	Endpoint           string
 	ExternalID         string
 	UserAgent          string
+	SessionToken       string
 	HTTPClient         *http.Client
 	ProxyOptions       *proxy.Options
 }
@@ -105,7 +106,7 @@ func (s Settings) WithEndpoint() LoadOptionsFunc {
 
 func (s Settings) WithStaticCredentials(client AWSAPIClient) LoadOptionsFunc {
 	return func(opts *config.LoadOptions) error {
-		opts.Credentials = client.NewStaticCredentialsProvider(s.AccessKey, s.SecretKey, "")
+		opts.Credentials = client.NewStaticCredentialsProvider(s.AccessKey, s.SecretKey, s.SessionToken)
 		return nil
 	}
 }


### PR DESCRIPTION
In reconstructing the auth code for aws-sdk-go-v2 I thought the SessionToken was never actually used, but I missed at least one case where it is. This restores the option to provide a session token when getting the AWS config.