### PR TITLE
Sigv4: Use externalId when signing with sigv4

### DIFF
--- a/pkg/sigv4/sigv4.go
+++ b/pkg/sigv4/sigv4.go
@@ -281,7 +281,7 @@ func createSigner(cfg *Config, authSettings awsds.AuthSettings, verboseMode bool
 	return newV4Signer(c, signerOpts), nil
 }
 
-func getAssumeRoleSigner(s *session.Session  , cfg *Config, signerOpts func(s *v4.Signer)) (*v4.Signer, error) {
+func getAssumeRoleSigner(s *session.Session, cfg *Config, signerOpts func(s *v4.Signer)) (*v4.Signer, error) {
 	if cfg.ExternalID != "" {
 		return newV4Signer(newStsCreds(s, cfg.AssumeRoleARN, func(p *stscreds.AssumeRoleProvider) {
 			p.ExternalID = aws.String(cfg.ExternalID)

--- a/pkg/sigv4/sigv4.go
+++ b/pkg/sigv4/sigv4.go
@@ -27,6 +27,8 @@ import (
 
 var (
 	signerCache sync.Map
+	newStsCreds = stscreds.NewCredentials
+	newV4Signer = v4.NewSigner
 )
 
 type middleware struct {
@@ -235,10 +237,10 @@ func createSigner(cfg *Config, authSettings awsds.AuthSettings, verboseMode bool
 			if err != nil {
 				return nil, err
 			}
-			c = stscreds.NewCredentials(s, cfg.AssumeRoleARN)
+			return getAssumeRoleSigner(s, cfg, signerOpts)
 		}
 
-		return v4.NewSigner(c, signerOpts), nil
+		return newV4Signer(c, signerOpts), nil
 	case awsds.AuthTypeDefault:
 		s, err := session.NewSession(&aws.Config{
 			Region: aws.String(cfg.Region),
@@ -251,7 +253,7 @@ func createSigner(cfg *Config, authSettings awsds.AuthSettings, verboseMode bool
 			return getAssumeRoleSigner(s, cfg, signerOpts)
 		}
 
-		return v4.NewSigner(s.Config.Credentials, signerOpts), nil
+		return newV4Signer(s.Config.Credentials, signerOpts), nil
 	default:
 		if cfg.AssumeRoleARN != "" {
 			s, err := session.NewSession(&aws.Config{
@@ -276,16 +278,16 @@ func createSigner(cfg *Config, authSettings awsds.AuthSettings, verboseMode bool
 		return getAssumeRoleSigner(s, cfg, signerOpts)
 	}
 
-	return v4.NewSigner(c, signerOpts), nil
+	return newV4Signer(c, signerOpts), nil
 }
 
 func getAssumeRoleSigner(s *session.Session  , cfg *Config, signerOpts func(s *v4.Signer)) (*v4.Signer, error) {
 	if cfg.ExternalID != "" {
-		return v4.NewSigner(stscreds.NewCredentials(s, cfg.AssumeRoleARN, func(p *stscreds.AssumeRoleProvider) {
+		return newV4Signer(newStsCreds(s, cfg.AssumeRoleARN, func(p *stscreds.AssumeRoleProvider) {
 			p.ExternalID = aws.String(cfg.ExternalID)
 		}), signerOpts), nil
 	} 
-	return v4.NewSigner(stscreds.NewCredentials(s, cfg.AssumeRoleARN), signerOpts), nil
+	return newV4Signer(newStsCreds(s, cfg.AssumeRoleARN), signerOpts), nil
 }
 
 func copyHeaderWithoutOverwrite(dst, src http.Header) {

--- a/pkg/sigv4/sigv4.go
+++ b/pkg/sigv4/sigv4.go
@@ -235,8 +235,9 @@ func createSigner(cfg *Config, authSettings awsds.AuthSettings, verboseMode bool
 			if err != nil {
 				return nil, err
 			}
-			return getAssumeRoleSigner(s, cfg, signerOpts) 
+			c = stscreds.NewCredentials(s, cfg.AssumeRoleARN)
 		}
+
 		return v4.NewSigner(c, signerOpts), nil
 	case awsds.AuthTypeDefault:
 		s, err := session.NewSession(&aws.Config{
@@ -249,6 +250,7 @@ func createSigner(cfg *Config, authSettings awsds.AuthSettings, verboseMode bool
 		if cfg.AssumeRoleARN != "" {
 			return getAssumeRoleSigner(s, cfg, signerOpts)
 		}
+
 		return v4.NewSigner(s.Config.Credentials, signerOpts), nil
 	default:
 		if cfg.AssumeRoleARN != "" {


### PR DESCRIPTION
It seems like `externalID` isn't passed when using sigv4 in AMP: https://github.com/grafana/grafana-amazonprometheus-datasource/issues/359

I added it it all the places assume role is applicable in sigv4. It would probably be good to refactor this function to reduce repetition a little bit, but ya know.
