### PR TITLE
Add AvailableMemory metric for the DMS service

### DIFF
--- a/pkg/cloudWatchConsts/metrics.go
+++ b/pkg/cloudWatchConsts/metrics.go
@@ -502,6 +502,7 @@ var NamespaceMetricsMap = map[string][]string{
 		"VolumePacketsPerSecond",
 	},
 	"AWS/DMS": {
+		"AvailableMemory",
 		"CDCChangesDiskSource",
 		"CDCChangesDiskTarget",
 		"CDCChangesMemorySource",


### PR DESCRIPTION
This PR adds the AvailableMemory metric for the DMS service.

Link to the AWS doc:

https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Monitoring.html#CHAP_Monitoring.Metrics:~:text=Description-,AvailableMemory,-An%20estimate%20of