### PR TITLE
Fix: Workspace IAM Role auth method does not need special handling

### DIFF
--- a/pkg/awsauth/auth.go
+++ b/pkg/awsauth/auth.go
@@ -42,16 +42,13 @@ func (rcp *awsConfigProvider) GetConfig(ctx context.Context, authSettings Settin
 	authType := authSettings.GetAuthType()
 	logger.Debug(fmt.Sprintf("Using auth type: %s", authType))
 	switch authType {
-	case AuthTypeDefault: // nothing else to do here
+	case AuthTypeDefault, AuthTypeEC2IAMRole: // nothing else to do here
 	case AuthTypeKeys:
 		options = append(options, authSettings.WithStaticCredentials(rcp.client))
 	case AuthTypeSharedCreds:
 		options = append(options, authSettings.WithSharedCredentials())
 	case AuthTypeGrafanaAssumeRole:
 		options = append(options, authSettings.WithGrafanaAssumeRole(ctx, rcp.client))
-	case AuthTypeEC2IAMRole:
-		// TODO: test this
-		options = append(options, authSettings.WithEC2RoleCredentials(rcp.client))
 	default:
 		return aws.Config{}, fmt.Errorf("unknown auth type: %s", authType)
 	}


### PR DESCRIPTION
AWS reported [customer issues with Athena v3.1.2](https://github.com/grafana/athena-datasource/issues/541) and after testing I determined that with aws-sdk-go-v2, the Workspace IAM / EC2 IAM auth method doesn't need special handling and should just go through the "Default" code path.