### PR TITLE
Fix: don't try to retrieve credentials before we need them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.38.5
+- Fix externalID handling by @njvrzm in [#246](https://github.com/grafana/grafana-aws-sdk/pull/246)
+- Add CloudWatch AWS/EKS metrics and dimensions by @jangaraj in [#242](https://github.com/grafana/grafana-aws-sdk/pull/242)
+- Bump github.com/grafana/grafana-plugin-sdk-go by @dependabot in [#241](https://github.com/grafana/grafana-aws-sdk/pull/241)
+
 ## 0.38.4
 - Add AvailableMemory metric for the DMS service by @andriikushch in [#244](https://github.com/grafana/grafana-aws-sdk/pull/244)
 - Github actions: Add token write permission by @idastambuk in [#243](https://github.com/grafana/grafana-aws-sdk/pull/243)

--- a/pkg/awsauth/auth.go
+++ b/pkg/awsauth/auth.go
@@ -66,11 +66,6 @@ func (rcp *awsConfigProvider) GetConfig(ctx context.Context, authSettings Settin
 		}
 	}
 
-	_, err = cfg.Credentials.Retrieve(ctx)
-	if err != nil {
-		return aws.Config{}, fmt.Errorf("error retrieving credentials: %w", err)
-	}
-
 	rcp.cache[key] = cfg
 	return cfg, nil
 }


### PR DESCRIPTION
This was causing an issue in Grafana Cloud where the `externalId` request would try to get credentials without a full configuration, causing an timeout and error.

Fixes https://github.com/grafana/athena-datasource/issues/546 (partially)
Also updates CHANGELOG for release.