### PR TITLE
Fix: use configured externalID when not using Grafana Assume Role

### DIFF
--- a/pkg/awsauth/auth.go
+++ b/pkg/awsauth/auth.go
@@ -3,6 +3,7 @@ package awsauth
 import (
 	"context"
 	"fmt"
+	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -48,6 +49,8 @@ func (rcp *awsConfigProvider) GetConfig(ctx context.Context, authSettings Settin
 	case AuthTypeSharedCreds:
 		options = append(options, authSettings.WithSharedCredentials())
 	case AuthTypeGrafanaAssumeRole:
+		settings, _ := awsds.ReadAuthSettingsFromContext(ctx)
+		authSettings.ExternalID = settings.ExternalID
 		options = append(options, authSettings.WithGrafanaAssumeRole(ctx, rcp.client))
 	default:
 		return aws.Config{}, fmt.Errorf("unknown auth type: %s", authType)

--- a/pkg/awsauth/test_utils.go
+++ b/pkg/awsauth/test_utils.go
@@ -55,11 +55,15 @@ func (m *mockAWSAPIClient) NewEC2RoleCreds() aws.CredentialsProvider {
 
 type mockAssumeRoleAPIClient struct {
 	mock.Mock
-	stsConfig aws.Config
+	stsConfig        aws.Config
+	calledExternalId string
 }
 
 func (m *mockAssumeRoleAPIClient) AssumeRole(_ context.Context, params *sts.AssumeRoleInput, _ ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
 	args := m.Called()
+	if params.ExternalId != nil {
+		m.calledExternalId = *params.ExternalId
+	}
 	if args.Bool(0) { // shouldError
 		return &sts.AssumeRoleOutput{}, fmt.Errorf("assume role failed")
 	}


### PR DESCRIPTION
After making a [fix](https://github.com/grafana/athena-datasource/pull/550) to the AWS Athena datasource to use the external ID from the Grafana config I realized that we actually need to take it from there only in the case of Grafana Assume Role, and use the customer-supplied external ID if they're configuring a different auth method. This handles that centrally, so we can remove the special handling from datasources [here](https://github.com/grafana/athena-datasource/blob/6c8f82f91ffad2ccc0005f405113240091cffbb5/pkg/athena/api/api.go#L69) and [here](https://github.com/grafana/grafana-cloudwatch-datasource/blob/ccf1f1b0274edd8cf12612d9e2fdbfd7b574cecc/pkg/cloudwatch/cloudwatch.go#L71).