### PR TITLE
Add missing opt in regions (thailand/mexico)

### DIFF
--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -109,6 +109,7 @@ func isOptInRegion(region string) bool {
 		"ap-south-2":     true,
 		"ap-southeast-3": true,
 		"ap-southeast-4": true,
+		"ap-southeast-7": true,
 		"ca-west-1":      true,
 		"eu-central-2":   true,
 		"eu-south-1":     true,
@@ -116,6 +117,7 @@ func isOptInRegion(region string) bool {
 		"il-central-1":   true,
 		"me-central-1":   true,
 		"me-south-1":     true,
+		"mx-central-1":   true,
 		// The rest of regions will return false
 	}
 	return regions[region]


### PR DESCRIPTION
Add missing opt in regions (Thailand and Mexico central) from [AWS docs](https://docs.aws.amazon.com/controltower/latest/userguide/opt-in-region-considerations.html).