### PR TITLE
Add SigV4 middleware for aws-sdk-go-v2

### DIFF
--- a/pkg/awsauth/auth.go
+++ b/pkg/awsauth/auth.go
@@ -3,9 +3,8 @@ package awsauth
 import (
 	"context"
 	"fmt"
-	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"strings"
 )

--- a/pkg/awsauth/settings.go
+++ b/pkg/awsauth/settings.go
@@ -18,6 +18,7 @@ import (
 	smithymiddleware "github.com/aws/smithy-go/middleware"
 
 	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
+	"github.com/grafana/grafana-aws-sdk/pkg/common"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
 	"github.com/grafana/grafana-plugin-sdk-go/build"
 )
@@ -144,6 +145,9 @@ func (s Settings) WithGrafanaAssumeRole(ctx context.Context, client AWSAPIClient
 }
 
 func (s Settings) WithAssumeRole(cfg aws.Config, client AWSAPIClient) LoadOptionsFunc {
+	if common.IsOptInRegion(cfg.Region) {
+		cfg.Region = "us-east-1"
+	}
 	stsClient := client.NewSTSClientFromConfig(cfg)
 	provider := client.NewAssumeRoleProvider(stsClient, s.AssumeRoleARN, func(options *stscreds.AssumeRoleOptions) {
 		if s.ExternalID != "" {

--- a/pkg/awsauth/sigv4.go
+++ b/pkg/awsauth/sigv4.go
@@ -1,0 +1,121 @@
+package awsauth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+)
+
+func NewSigV4Middleware(signerOpts ...func(signer *v4.SignerOptions)) httpclient.Middleware {
+	return SignerMiddleware{signerOpts}
+}
+
+type SignerMiddleware struct {
+	signerOpts []func(*v4.SignerOptions)
+}
+
+func (s SignerMiddleware) CreateMiddleware(opts httpclient.Options, next http.RoundTripper) http.RoundTripper {
+	if opts.SigV4 == nil {
+		return next
+	}
+	return NewSignerRoundTripper(opts, next, v4.NewSigner(s.signerOpts...))
+}
+
+func (s SignerMiddleware) MiddlewareName() string {
+	return "sigv4"
+}
+
+func NewSignerRoundTripper(opts httpclient.Options, next http.RoundTripper, signer v4.HTTPSigner) SignerRoundTripper {
+	return SignerRoundTripper{
+		sigV4Config:       opts.SigV4,
+		customHeaders:     opts.Header,
+		next:              next,
+		awsConfigProvider: NewConfigProvider(),
+		signer:            signer,
+		clock:             systemClock{},
+	}
+}
+
+type SignerRoundTripper struct {
+	sigV4Config       *httpclient.SigV4Config
+	customHeaders     http.Header
+	next              http.RoundTripper
+	awsConfigProvider ConfigProvider
+	signer            v4.HTTPSigner
+	clock             Clock
+}
+
+func (s SignerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	awsAuthSettings := Settings{
+		AuthType:           AuthType(s.sigV4Config.AuthType),
+		AccessKey:          s.sigV4Config.AccessKey,
+		SecretKey:          s.sigV4Config.SecretKey,
+		Region:             s.sigV4Config.Region,
+		CredentialsProfile: s.sigV4Config.Profile,
+		AssumeRoleARN:      s.sigV4Config.AssumeRoleARN,
+		ExternalID:         s.sigV4Config.ExternalID,
+		// TODO: support PDC:
+		//ProxyOptions:       nil,
+	}
+	ctx := req.Context()
+	cfg, err := s.awsConfigProvider.GetConfig(ctx, awsAuthSettings)
+	if err != nil {
+		return nil, err
+	}
+	credentials, err := cfg.Credentials.Retrieve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	err = s.SignHTTP(ctx, req, credentials)
+	if err != nil {
+		return nil, err
+	}
+	return s.next.RoundTrip(req)
+}
+
+func (s SignerRoundTripper) SignHTTP(ctx context.Context, req *http.Request, credentials aws.Credentials) error {
+	// remove any custom headers from req, so they don't get included in the signature
+	for k := range s.customHeaders {
+		req.Header.Del(k)
+	}
+	defer func() {
+		// replace the custom headers before returning
+		for k, v := range s.customHeaders {
+			req.Header[k] = v
+		}
+	}()
+	payloadHash, err := getRequestBodyHash(req)
+	if err != nil {
+		return err
+	}
+	return s.signer.SignHTTP(ctx, credentials, req, payloadHash, s.sigV4Config.Service, s.sigV4Config.Region, s.clock.Now().UTC())
+}
+
+func getRequestBodyHash(req *http.Request) (string, error) {
+	body, err := req.GetBody()
+	if err != nil {
+		return "", err
+	}
+	hash := sha256.New()
+	_, err = io.Copy(hash, body)
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+
+}
+
+type Clock interface {
+	Now() time.Time
+}
+type systemClock struct{}
+
+func (systemClock) Now() time.Time { return time.Now() }

--- a/pkg/awsauth/sigv4_test.go
+++ b/pkg/awsauth/sigv4_test.go
@@ -1,0 +1,133 @@
+package awsauth
+
+import (
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+const EmptySha256Hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+var OnceUponATime = time.Unix(1234567890, 0) // 2009-02-13 UTC
+var AtALaterTime = time.Unix(1234567891, 0)  // 2009-02-13 UTC
+
+func TestSignerRoundTripper_SignHTTP(t *testing.T) {
+	tests := []struct {
+		name           string
+		sigV4Config    *httpclient.SigV4Config
+		requestBody    string
+		customHeaders  http.Header
+		differentTimes bool
+	}{
+		{
+			name: "basic success",
+			sigV4Config: &httpclient.SigV4Config{
+				AuthType:  "keys",
+				AccessKey: "good",
+				SecretKey: "excellent",
+				Region:    "us-east-1",
+			},
+		},
+		{
+			name: "with custom headers",
+			sigV4Config: &httpclient.SigV4Config{
+				AuthType:  "keys",
+				AccessKey: "good",
+				SecretKey: "excellent",
+				Region:    "us-east-1",
+			},
+			customHeaders: http.Header{"X-Testing-Stuff": []string{"is good"}},
+		},
+		{
+			name: "signature changes with different time",
+			sigV4Config: &httpclient.SigV4Config{
+				AuthType:  "keys",
+				AccessKey: "good",
+				SecretKey: "excellent",
+				Region:    "us-east-1",
+			},
+			differentTimes: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			next := &testRoundTripper{}
+			s := NewSignerRoundTripper(httpclient.Options{SigV4: tt.sigV4Config}, next, v4.NewSigner())
+			s.awsConfigProvider = NewFakeConfigProvider(false)
+			s.clock = staticClock{OnceUponATime}
+
+			req, _ := http.NewRequest("GET", "https://service.aws.amazon.notreally", strings.NewReader(tt.requestBody))
+			_, err := s.RoundTrip(req)
+			require.NoError(t, err)
+			require.NotEmpty(t, req.Header["Authorization"])
+
+			if tt.customHeaders != nil {
+				s.customHeaders = tt.customHeaders
+				reqWithHeaders, _ := http.NewRequest("GET", "https://service.aws.amazon.notreally", strings.NewReader(tt.requestBody))
+				reqWithHeaders.Header = tt.customHeaders
+				_, err = s.RoundTrip(reqWithHeaders)
+				require.NoError(t, err)
+
+				// custom headers should not affect the signature
+				require.Equal(t, req.Header["Authorization"], reqWithHeaders.Header["Authorization"])
+				// ... but should be retained
+				for k, v := range tt.customHeaders {
+					require.Equal(t, v, reqWithHeaders.Header[k])
+				}
+			}
+			if tt.differentTimes {
+				s.clock = staticClock{AtALaterTime}
+				reqLater, _ := http.NewRequest("GET", "https://service.aws.amazon.notreally", strings.NewReader(tt.requestBody))
+				_, err = s.RoundTrip(reqLater)
+				require.NoError(t, err)
+				require.NotEqual(t, req.Header["Authorization"], reqLater.Header["Authorization"])
+
+			}
+		})
+	}
+}
+func Test_getRequestBodyHash(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		expected string
+	}{
+		{
+			name:     "empty body is empty hash",
+			body:     "",
+			expected: EmptySha256Hash,
+		},
+		{
+			name:     "hello world",
+			body:     "hello world",
+			expected: "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("get", "https://whatever.wherever:999", strings.NewReader(tt.body))
+			got, _ := getRequestBodyHash(req)
+			assert.Equalf(t, tt.expected, got, "getRequestBodyHash(%v)", req)
+		})
+	}
+}
+
+type staticClock struct {
+	when time.Time
+}
+
+func (s staticClock) Now() time.Time { return s.when }
+
+type testRoundTripper struct {
+	seen *http.Request
+}
+
+func (t *testRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	t.seen = request
+	return &http.Response{Status: "everything is awesome", StatusCode: 200}, nil
+}

--- a/pkg/awsauth/sigv4_test.go
+++ b/pkg/awsauth/sigv4_test.go
@@ -67,7 +67,6 @@ func TestSignerRoundTripper_SignHTTP(t *testing.T) {
 			require.NotEmpty(t, req.Header["Authorization"])
 
 			if tt.customHeaders != nil {
-				s.customHeaders = tt.customHeaders
 				reqWithHeaders, _ := http.NewRequest("GET", "https://service.aws.amazon.notreally", strings.NewReader(tt.requestBody))
 				reqWithHeaders.Header = tt.customHeaders
 				_, err = s.RoundTrip(reqWithHeaders)

--- a/pkg/awsds/sessions.go
+++ b/pkg/awsds/sessions.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grafana/grafana-aws-sdk/pkg/common"
+
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 
@@ -101,30 +103,6 @@ type SessionConfig struct {
 	AuthSettings  *AuthSettings
 }
 
-func isOptInRegion(region string) bool {
-	// Opt-in region from https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
-	regions := map[string]bool{
-		"af-south-1":     true,
-		"ap-east-1":      true,
-		"ap-east-2":      true,
-		"ap-south-2":     true,
-		"ap-southeast-3": true,
-		"ap-southeast-4": true,
-		"ap-southeast-5": true,
-		"ap-southeast-7": true,
-		"ca-west-1":      true,
-		"eu-central-2":   true,
-		"eu-south-1":     true,
-		"eu-south-2":     true,
-		"il-central-1":   true,
-		"me-central-1":   true,
-		"me-south-1":     true,
-		"mx-central-1":   true,
-		// The rest of regions will return false
-	}
-	return regions[region]
-}
-
 // Deprecated: use GetSessionWithAuthSettings instead
 func (sc *SessionCache) GetSession(c SessionConfig) (*session.Session, error) {
 	if c.Settings.Region == "" && c.Settings.DefaultRegion != "" {
@@ -193,7 +171,7 @@ func (sc *SessionCache) GetSession(c SessionConfig) (*session.Session, error) {
 		c.Settings.Region = ""
 	}
 	if c.Settings.Region != "" {
-		if c.Settings.AssumeRoleARN != "" && c.AuthSettings.AssumeRoleEnabled && isOptInRegion(c.Settings.Region) {
+		if c.Settings.AssumeRoleARN != "" && c.AuthSettings.AssumeRoleEnabled && common.IsOptInRegion(c.Settings.Region) {
 			// When assuming a role, the real region is set later in a new session
 			// so we use a well-known region here (not opt-in) to obtain valid credentials
 			regionCfg = &aws.Config{Region: aws.String("us-east-1")}

--- a/pkg/common/opt_in.go
+++ b/pkg/common/opt_in.go
@@ -1,0 +1,24 @@
+package common
+
+func IsOptInRegion(region string) bool {
+	// Opt-in regions listed at https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html
+	regions := map[string]bool{
+		"af-south-1":     true,
+		"ap-east-1":      true,
+		"ap-east-2":      true,
+		"ap-south-2":     true,
+		"ap-southeast-3": true,
+		"ap-southeast-4": true,
+		"ap-southeast-5": true,
+		"ap-southeast-7": true,
+		"ca-west-1":      true,
+		"eu-central-2":   true,
+		"eu-south-1":     true,
+		"eu-south-2":     true,
+		"il-central-1":   true,
+		"me-central-1":   true,
+		"me-south-1":     true,
+		"mx-central-1":   true,
+	}
+	return regions[region]
+}


### PR DESCRIPTION
This adds a replacement for the old SigV4 signing middleware, removing the dependency on aws-sdk-go v1.