### PR TITLE
Fix transport and cache bugs

### DIFF
--- a/pkg/awsauth/settings.go
+++ b/pkg/awsauth/settings.go
@@ -183,7 +183,11 @@ func (s Settings) WithHTTPClient() LoadOptionsFunc {
 			options.HTTPClient = s.HTTPClient
 		}
 		if options.HTTPClient == nil {
-			options.HTTPClient = http.DefaultClient
+			client, err := httpclient.New()
+			if err != nil {
+				return err
+			}
+			options.HTTPClient = client
 		}
 		if s.ProxyOptions != nil {
 			if client, ok := options.HTTPClient.(*http.Client); ok {


### PR DESCRIPTION
This fixes two issues:
- The ConfigProvider's cache was not safe for concurrent use
- The use of http.DefaultTransport was not safe in a multitenant environment.