### PR TITLE
Fix: handle (and try to avoid) panic in sigv4 middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.0.4
+- Fix: handle (and try to avoid) panic in sigv4 middleware by @njvrzm in [#269](https://github.com/grafana/grafana-aws-sdk/pull/269)
+- Remove pr_commands by @kevinwcyu in [#266](https://github.com/grafana/grafana-aws-sdk/pull/266)
+
 ## 1.0.3
 
 - Fix transport and cache bugs by @njvrzm in [#267](https://github.com/grafana/grafana-aws-sdk/pull/267)


### PR DESCRIPTION
This is an attempt to avoid or at least recover from a panic we're seeing in some rare cases with the SigV4 middleware when used by Prometheus.