### PR TITLE
Add CloudWatch Network Monitor namespace

### DIFF
--- a/pkg/cloudWatchConsts/metrics.go
+++ b/pkg/cloudWatchConsts/metrics.go
@@ -2551,7 +2551,7 @@ var NamespaceMetricsMap = map[string][]string{
 		"HealthIndicator",
 		"PacketLoss",
 		"RTT",
-	}
+	},
 	"AWS/OpsWorks": {
 		"cpu_idle",
 		"cpu_nice",


### PR DESCRIPTION
## Proposed Changes

- Adds `AWS/NetworkMonitor`

I cannot find a definitive source for this, however its referenced [here](https://aws.amazon.com/blogs/networking-and-content-delivery/monitor-hybrid-connectivity-with-amazon-cloudwatch-network-monitor/#:~:text=metrics%20summary%20view-,CloudWatch%20Metrics,-AWS%20Network%20Monitor)

>AWS Network Monitor publishes metrics to CloudWatch Metrics under the AWS/NetworkMonitor namespace. We will find three metrics for each of our probes:
> - HealthIndicator: 0 if AWS Network is healthy at the time of the measurement, and 1 if it is degraded.
> - PacketLoss: packet loss as a percent value.
> - RTT: round-trip time in microseconds.

Signed-off-by: Jacob Woffenden <jacob@woffenden.io>