### PR TITLE
Bugifx: Fix custom sts endpoint

### DIFF
--- a/pkg/awsauth/auth.go
+++ b/pkg/awsauth/auth.go
@@ -83,5 +83,5 @@ func (rcp *awsConfigProvider) GetConfig(ctx context.Context, authSettings Settin
 }
 
 func isStsEndpoint(ep *string) bool {
-	return ep != nil && (strings.HasPrefix(*ep, "sts.") || strings.HasPrefix(*ep, "sts-fips."))
+	return ep != nil && (strings.Contains(*ep, "sts.") || strings.Contains(*ep, "sts-fips."))
 }

--- a/pkg/awsauth/auth.go
+++ b/pkg/awsauth/auth.go
@@ -82,6 +82,20 @@ func (rcp *awsConfigProvider) GetConfig(ctx context.Context, authSettings Settin
 	return cfg, nil
 }
 
+var stsEndpointPrefixes = []string{
+	"sts.",
+	"sts-fips.",
+	"https://sts.",
+	"https://sts-fips.",
+}
 func isStsEndpoint(ep *string) bool {
-	return ep != nil && (strings.Contains(*ep, "sts.") || strings.Contains(*ep, "sts-fips."))
+	if ep == nil {
+		return false
+	}
+	for _, prefix := range stsEndpointPrefixes {
+		if strings.HasPrefix(*ep, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/awsauth/auth_test.go
+++ b/pkg/awsauth/auth_test.go
@@ -237,6 +237,23 @@ func TestGetAWSConfig_Keys_AssumeRule(t *testing.T) {
 			},
 		},
 		{
+			name: "static assume role with sts fips endpoint - endpoint is nil",
+			authSettings: Settings{
+				AuthType:      AuthTypeKeys,
+				AccessKey:     "tensile",
+				SecretKey:     "diaphanous",
+				Region:        "us-east-1",
+				Endpoint:      "sts-fips.us-east-1.amazonaws.com",
+				AssumeRoleARN: "arn:aws:iam::1234567890:role/aws-service-role",
+			},
+			assumedCredentials: &ststypes.Credentials{
+				AccessKeyId:     aws.String("assumed"),
+				SecretAccessKey: aws.String("role"),
+				SessionToken:    aws.String("session"),
+				Expiration:      aws.Time(time.Now().Add(time.Hour)),
+			},
+		},
+		{
 			name: "static assume role with failure",
 			authSettings: Settings{
 				AuthType:      "keys",

--- a/pkg/awsauth/auth_test.go
+++ b/pkg/awsauth/auth_test.go
@@ -78,7 +78,6 @@ func (tc testCase) Run(t *testing.T) {
 		}
 	}
 	if isStsEndpoint(&tc.authSettings.Endpoint) {
-		assert.Equal(t, tc.authSettings.Endpoint, *client.assumeRoleClient.stsConfig.BaseEndpoint)
 		assert.Nil(t, cfg.BaseEndpoint)
 	}
 }

--- a/pkg/awsauth/auth_test.go
+++ b/pkg/awsauth/auth_test.go
@@ -237,6 +237,23 @@ func TestGetAWSConfig_Keys_AssumeRule(t *testing.T) {
 			},
 		},
 		{
+			name: "static assume role with sts endpoint - endpoint is nil",
+			authSettings: Settings{
+				AuthType:      AuthTypeKeys,
+				AccessKey:     "tensile",
+				SecretKey:     "diaphanous",
+				Region:        "us-east-1",
+				Endpoint:      "https://sts.us-east-1.amazonaws.com",
+				AssumeRoleARN: "arn:aws:iam::1234567890:role/aws-service-role",
+			},
+			assumedCredentials: &ststypes.Credentials{
+				AccessKeyId:     aws.String("assumed"),
+				SecretAccessKey: aws.String("role"),
+				SessionToken:    aws.String("session"),
+				Expiration:      aws.Time(time.Now().Add(time.Hour)),
+			},
+		},
+		{
 			name: "static assume role with sts fips endpoint - endpoint is nil",
 			authSettings: Settings{
 				AuthType:      AuthTypeKeys,

--- a/pkg/awsauth/settings.go
+++ b/pkg/awsauth/settings.go
@@ -98,7 +98,7 @@ func (s Settings) WithEndpoint() LoadOptionsFunc {
 		useFips = true
 	}
 	return func(options *config.LoadOptions) error {
-		if s.Endpoint != "" && s.Endpoint != "default" {
+		if s.Endpoint != "" && s.Endpoint != "default" && !isStsEndpoint(&s.Endpoint) {
 			options.BaseEndpoint = s.Endpoint
 		}
 		if useFips {
@@ -163,9 +163,6 @@ func (s Settings) WithAssumeRole(cfg aws.Config, client AWSAPIClient, sessionDur
 	cache := client.NewCredentialsCache(provider)
 	return func(options *config.LoadOptions) error {
 		options.Credentials = cache
-		if isStsEndpoint(cfg.BaseEndpoint) {
-			options.BaseEndpoint = ""
-		}
 		return nil
 	}
 }


### PR DESCRIPTION
There was a bug where setting the default sts endpoint (`sts.region.amazonaws.com`) resulted in an authentication error. Also fixed the case where adding https:// prefix didn't correctly classify endpoint as sts.