### PR TITLE
Tweak dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      time: "08:00"
+    open-pull-requests-limit: 3
     cooldown:
       semver-major-days: 30
       semver-minor-days: 14
@@ -14,6 +16,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      time: "12:00"
+    open-pull-requests-limit: 3
     cooldown:
       default-days: 7
       exclude:


### PR DESCRIPTION
- Set the time when dependabot updates happen:
  - go updates at 8am UTC
  - npm updates at 10am UTC
  - github actions updates at 12pm UTC
- Limit the number of open PRs to 3 per package ecosystem
- Reordered the package ecosystems, moved `package-ecosystem: 'github-actions'` below `package-ecosystem: 'npm'`