### PR TITLE
Add clusterId dimension to AWS/ElastiCache namespace

### DIFF
--- a/pkg/cloudWatchConsts/metrics.go
+++ b/pkg/cloudWatchConsts/metrics.go
@@ -3428,7 +3428,7 @@ var NamespaceDimensionKeysMap = map[string][]string{
 	"AWS/EKS":                            {"ClusterName"},
 	"AWS/ELB":                            {"AvailabilityZone", "LoadBalancerName"},
 	"AWS/ES":                             {"ClientId", "DomainName", "NodeId"},
-	"AWS/ElastiCache":                    {"CacheClusterId", "CacheNodeId"},
+	"AWS/ElastiCache":                    {"CacheClusterId", "CacheNodeId", "clusterId"},
 	"AWS/ElasticBeanstalk":               {"EnvironmentName", "InstanceId"},
 	"AWS/ElasticInference":               {"ElasticInferenceAcceleratorId", "InstanceId"},
 	"AWS/ElasticMapReduce":               {"ClusterId", "JobFlowId", "JobId"},


### PR DESCRIPTION
Running the following to show the available dimensions for the "AWS/ElastiCache" namespace only returns `clusterId`

```sh
aws cloudwatch list-metrics --namespace AWS/ElastiCache --region us-east-2  | jq '[.Metrics[].Dimensions[].Name] | unique'
[
  "clusterId"
]
```

I created an ElastiCache cluster named "test" and when I manually set the dimension name to `clusterId`, it correctly fetches the value "test". The existing `CacheClusterId` and `CacheNodeId` are documented but don't seem to return anything.
 
<img width="267" height="157" alt="Screenshot 2025-08-27 at 11 27 18 AM" src="https://github.com/user-attachments/assets/b56c39a1-bdcf-4c5a-901c-8ee1743db628" />

This adds the `clusterId` as a dimension for "AWS/ElastiCache". It being lowercase is a bit unusual, but there's already other dimensions like that e.g. `"AWS/Redshift":                       {"ClusterIdentifier", "NodeID", "service class", "stage", "latency", "wlmid"},`

This is for https://github.com/grafana/grafana/issues/110038