### PR TITLE
Add missing ap-southeast-6 opt in region

### DIFF
--- a/pkg/common/opt_in.go
+++ b/pkg/common/opt_in.go
@@ -10,6 +10,7 @@ func IsOptInRegion(region string) bool {
 		"ap-southeast-3": true,
 		"ap-southeast-4": true,
 		"ap-southeast-5": true,
+		"ap-southeast-6": true,
 		"ap-southeast-7": true,
 		"ca-west-1":      true,
 		"eu-central-2":   true,


### PR DESCRIPTION
See https://github.com/grafana/grafana/issues/113011

Add missing ap-southeast-6 opt in region. Docs: https://docs.aws.amazon.com/general/latest/gr/cw_region.html