### PR TITLE
fix bedrock metrics with split namespaces

### DIFF
--- a/pkg/cloudWatchConsts/metrics.go
+++ b/pkg/cloudWatchConsts/metrics.go
@@ -331,8 +331,8 @@ var NamespaceMetricsMap = map[string][]string{
 	},
 	"AWS/Bedrock/Agents": {
 		"InputTokenCount",
-		"InvocationCount",
 		"InvocationClientErrors",
+		"InvocationCount",
 		"InvocationServerErrors",
 		"InvocationThrottles",
 		"ModelInvocationClientErrors",


### PR DESCRIPTION
This is a follow up for https://github.com/grafana/grafana-aws-sdk/pull/350, part of https://github.com/grafana/cloud-onboarding/issues/9800

It turns out that `AWS/Bedrock` is actually split to include two additional sub-namespaces now: `AWS/Bedrock/Agents` and `AWS/Bedrock/Guardrails`. I've updated the mapping to account for this.