### PR TITLE
Better handle an empty body

### DIFF
--- a/pkg/sql/routes/routes.go
+++ b/pkg/sql/routes/routes.go
@@ -24,6 +24,9 @@ func Write(rw http.ResponseWriter, b []byte) {
 
 func ParseBody(body io.ReadCloser) (sqlds.Options, error) {
 	reqBody := sqlds.Options{}
+	if body == nil {
+		return reqBody, nil
+	}
 	b, err := io.ReadAll(body)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Problem

I saw a panic in Grafana:
```
logger=plugin.grafana-athena-datasource t=2026-04-30T16:50:23.889132361Z level=error msg="panic triggered" error="runtime error: invalid memory address or nil pointer dereference" stack="goroutine 123601 [running]:
```
```
runtime/debug.Stack()
\t/usr/local/go/src/runtime/debug/stack.go:26 +0x5e
github.com/grafana/grafana-plugin-sdk-go/backend.handlePanic({0x17118c0, 0x2ac0a80})
\t/go/pkg/mod/github.com/grafana/grafana-plugin-sdk-go@v0.277.1/backend/serve.go:137 +0x25
github.com/grafana/grafana-plugin-sdk-go/backend.defaultGRPCMiddlewares.WithRecoveryHandler.func6.1({0xc001414518?, 0x0?}, {0x17118c0?, 0x2ac0a80?})
\t/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.3.2/interceptors/recovery/options.go:36 +0x27
github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery.recoverFrom({0x1cfddf0?, 0xc0017cee70?}, {0x17118c0?, 0x2ac0a80?}, 0xc00141451f?)
\t/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.3.2/interceptors/recovery/interceptors.go:54 +0xea
github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery.StreamServerInterceptor.func1.1()
\t/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.3.2/interceptors/recovery/interceptors.go:44 +0x7b
panic({0x17118c0?, 0x2ac0a80?})
\t/usr/local/go/src/runtime/panic.go:792 +0x132
io.ReadAll({0x0, 0x0})
\t/usr/local/go/src/io/io.go:712 +0x4d
github.com/grafana/grafana-aws-sdk/pkg/sql/routes.ParseBody({0x0, 0x0})
\t/go/pkg/mod/github.com/grafana/grafana-aws-sdk@v0.38.6/pkg/sql/routes/routes.go:27 +0x85
github.com/grafana/athena-datasource/pkg/athena/routes.(*AthenaResourceHandler).catalogs(0xc000786ea0, {0x1cfb6e0, 0xc0017cf2f0}, 0xc000c66780)
...
```

The stacktrace goes on but this feels like the most important part. Specfically:
```
panic({0x17118c0?, 0x2ac0a80?})
\t/usr/local/go/src/runtime/panic.go:792 +0x132
io.ReadAll({0x0, 0x0})
\t/usr/local/go/src/io/io.go:712 +0x4d
github.com/grafana/grafana-aws-sdk/pkg/sql/routes.ParseBody({0x0, 0x0})
```

It seems like somehow `ParseBody` was called with a `nil` body. I haven't dug too too deeply into this call chain but from `athena-datasource` I can see:
```
func (r *AthenaResourceHandler) catalogs(rw http.ResponseWriter, req *http.Request) {
	reqBody, err := routes.ParseBody(req.Body)
	if err != nil {
		rw.WriteHeader(http.StatusBadRequest)
		routes.Write(rw, []byte(err.Error()))
		return
	}
	res, err := r.athena.DataCatalogs(req.Context(), reqBody)
	routes.SendResources(rw, res, err)
}
```

## Solution

My first instinct was to fix athena-datasource but I thought about it more and realized that this could be encountered by other plugins and it might be better to fix here. From there I hesitated between returning the body or an error but opted to return the body.