### PR TITLE
Fix: restore s3 support for SigV4

### DIFF
--- a/pkg/awsauth/sigv4.go
+++ b/pkg/awsauth/sigv4.go
@@ -99,11 +99,19 @@ func (s SignerRoundTripper) SignHTTP(ctx context.Context, req *http.Request, cre
 			req.Header[k] = v
 		}
 	}()
+	var signerOptions []func(options *v4.SignerOptions)
 	payloadHash, err := getRequestBodyHash(req)
+	// support s3 for grafana-infinity-datasource
+	if s.httpOptions.SigV4.Service == "s3" {
+		req.Header.Add("X-Amz-Content-Sha256", payloadHash)
+		signerOptions = append(signerOptions, func(options *v4.SignerOptions) {
+			options.DisableURIPathEscaping = true
+		})
+	}
 	if err != nil {
 		return err
 	}
-	return s.signer.SignHTTP(ctx, credentials, req, payloadHash, s.httpOptions.SigV4.Service, s.httpOptions.SigV4.Region, s.clock.Now().UTC())
+	return s.signer.SignHTTP(ctx, credentials, req, payloadHash, s.httpOptions.SigV4.Service, s.httpOptions.SigV4.Region, s.clock.Now().UTC(), signerOptions...)
 }
 
 func getRequestBodyHash(req *http.Request) (string, error) {


### PR DESCRIPTION
With the upgrade to aws-sdk-go-v2 last year, the SigV4 signer stopped supporting the S3 service. This is used by grafana-infinity-datasource - see https://github.com/grafana/grafana-infinity-datasource/issues/1299. This PR restores that functionality by:
* disabling URI escaping, which can interfere with the signature verification
* Adding the `X-Amz-Content-Sha256` header, which is required for S3.
