### PR TITLE
chore: security hardening for CI and dependencies

### DIFF
--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -16,10 +16,11 @@ jobs:
         with:
           repository: "grafana/grafana-github-actions"
           path: ./actions
-          ref: main
+          # Pin to a commit SHA; refresh periodically from grafana/grafana-github-actions main.
+          ref: 3c62d35c5a66e730186a338e45aeb8fa784e2d56
           persist-credentials: false
       - name: Install Actions
-        run: npm install --production --prefix ./actions
+        run: npm install --production --ignore-scripts --prefix ./actions
       - name: Get GitHub App token
         id: get-github-app-token
         uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,36 +11,32 @@ permissions: {}
 jobs:
   go-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
 
-      - name: Mage
+      - name: Install tools
         shell: bash
         run: |
-          go install github.com/magefile/mage@latest
-
-      - name: golangci-lint
-        shell: bash
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v${GOLANGCI_LINT_VERSION}
-        env:
-          GOLANGCI_LINT_VERSION: "2.8.0"
-
-      - name: Install dependencies
-        run: go mod download
-        working-directory: ${{ inputs.plugin-directory }}
-        shell: bash
+          go install github.com/magefile/mage@v1.17.1
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0
 
       - name: Lint
         run: golangci-lint run --timeout=5m
         shell: bash
+
+      - name: govulncheck
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...
 
       - name: Test
         run: mage -v test

--- a/Magefile.go
+++ b/Magefile.go
@@ -14,7 +14,7 @@ func Build() error {
 
 // Test runs the test suite.
 func Test() error {
-	return sh.RunV("go", "test", "./...")
+	return sh.RunV("go", "test", "-race", "./...")
 }
 
 func Lint() error {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-aws-sdk
 
-go 1.25.7
+go 1.25.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.5
@@ -113,3 +113,5 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+tool github.com/magefile/mage


### PR DESCRIPTION
## Summary
- Pin CI tools (`mage@v1.17.1`, `golangci-lint@v2.8.0`) and replace `curl | sh` install pattern
- Pin `grafana/grafana-github-actions` checkout to a commit SHA; add `--ignore-scripts` on npm install
- Tighten `push.yml` permissions (`contents: read`, `persist-credentials: false`)
- Enable race detector in `mage test`
- Bump Go to `1.25.11` and add strict `govulncheck@v1.3.0` (pinned; `v1.4.0` panics on this codebase)
- Mark `mage` as a `tool` dependency in `go.mod`

## Test plan
- [ ] CI passes on this PR (`Go CI` workflow: lint, govulncheck, race tests, build)
- [ ] Issue label commands still work after `grafana-github-actions` SHA pin (manual spot-check if needed)


Made with [Cursor](https://cursor.com)