### PR TITLE
fix(awsauth): hash request body when GetBody is nil

### DIFF
--- a/pkg/awsauth/sigv4.go
+++ b/pkg/awsauth/sigv4.go
@@ -1,6 +1,7 @@
 package awsauth
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -116,7 +117,7 @@ func (s SignerRoundTripper) SignHTTP(ctx context.Context, req *http.Request, cre
 
 func getRequestBodyHash(req *http.Request) (string, error) {
 	if req.GetBody == nil {
-		return EmptySha256Hash, nil
+		return getServerRequestBodyHash(req)
 	}
 	body, err := req.GetBody()
 	if err != nil {
@@ -129,6 +130,30 @@ func getRequestBodyHash(req *http.Request) (string, error) {
 	}
 	return hex.EncodeToString(hash.Sum(nil)), nil
 
+}
+
+// getServerRequestBodyHash hashes the body of a request that has no GetBody.
+// net/http only populates GetBody on client requests, so requests forwarded by
+// a reverse proxy (e.g. Grafana's datasource proxy) carry their payload in
+// Body alone. The body is buffered so it can be hashed here and still be sent
+// downstream, and GetBody is populated for any later reads.
+func getServerRequestBodyHash(req *http.Request) (string, error) {
+	if req.Body == nil || req.Body == http.NoBody {
+		return EmptySha256Hash, nil
+	}
+	payload, err := io.ReadAll(req.Body)
+	if err != nil {
+		return "", err
+	}
+	if err := req.Body.Close(); err != nil {
+		return "", err
+	}
+	req.Body = io.NopCloser(bytes.NewReader(payload))
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(payload)), nil
+	}
+	hash := sha256.Sum256(payload)
+	return hex.EncodeToString(hash[:]), nil
 }
 
 type Clock interface {

--- a/pkg/awsauth/sigv4_test.go
+++ b/pkg/awsauth/sigv4_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -112,6 +113,85 @@ func Test_getRequestBodyHash(t *testing.T) {
 			assert.Equalf(t, tt.expected, got, "getRequestBodyHash(%v)", req)
 		})
 	}
+}
+
+func Test_getRequestBodyHash_serverStyleRequest(t *testing.T) {
+	// Requests forwarded by a reverse proxy (e.g. Grafana's datasource proxy)
+	// carry a Body but never GetBody, which net/http only sets on client
+	// requests. The body must still be hashed, and must remain readable for
+	// the downstream round trip.
+	tests := []struct {
+		name     string
+		body     io.ReadCloser
+		expected string
+	}{
+		{
+			name:     "nil body is empty hash",
+			body:     nil,
+			expected: EmptySha256Hash,
+		},
+		{
+			name:     "http.NoBody is empty hash",
+			body:     http.NoBody,
+			expected: EmptySha256Hash,
+		},
+		{
+			name:     "non-empty body is hashed",
+			body:     io.NopCloser(strings.NewReader("hello world")),
+			expected: "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("POST", "https://whatever.wherever:999", nil)
+			req.Body = tt.body
+
+			got, err := getRequestBodyHash(req)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+
+			if tt.body != nil && tt.body != http.NoBody {
+				require.NotNil(t, req.Body, "body must remain readable after hashing")
+				remaining, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				assert.Equal(t, "hello world", string(remaining), "body must be intact after hashing")
+			}
+		})
+	}
+}
+
+func TestSignerRoundTripper_SignHTTP_proxiedRequestMatchesClientRequest(t *testing.T) {
+	sigV4Config := &httpclient.SigV4Config{
+		AuthType:  "keys",
+		AccessKey: "good",
+		SecretKey: "excellent",
+		Region:    "us-east-1",
+	}
+	body := "{\"index\":\"metrics-*\"}\n{\"query\":{\"match_all\":{}}}\n"
+
+	next := &testRoundTripper{}
+	s := NewSignerRoundTripper(httpclient.Options{SigV4: sigV4Config}, next, v4.NewSigner())
+	s.awsConfigProvider = NewFakeConfigProvider(false)
+	s.clock = staticClock{OnceUponATime}
+
+	clientReq, _ := http.NewRequest("POST", "https://service.aws.amazon.notreally/_msearch", strings.NewReader(body))
+	_, err := s.RoundTrip(clientReq)
+	require.NoError(t, err)
+
+	// A proxied request has Body set but GetBody nil, as produced by
+	// httputil.ReverseProxy forwarding an inbound server request.
+	proxiedReq, _ := http.NewRequest("POST", "https://service.aws.amazon.notreally/_msearch", nil)
+	proxiedReq.Body = io.NopCloser(strings.NewReader(body))
+	proxiedReq.ContentLength = int64(len(body))
+	_, err = s.RoundTrip(proxiedReq)
+	require.NoError(t, err)
+
+	require.Equal(t, clientReq.Header["Authorization"], proxiedReq.Header["Authorization"],
+		"identical payloads must produce identical signatures regardless of GetBody being set")
+
+	sentBody, err := io.ReadAll(next.seen.Body)
+	require.NoError(t, err)
+	assert.Equal(t, body, string(sentBody), "proxied request body must reach the next round tripper intact")
 }
 
 type staticClock struct {


### PR DESCRIPTION
## What

`getRequestBodyHash` returned the empty-body SHA256 whenever `req.GetBody` was nil, even when `req.Body` carried a payload. The body is now buffered and hashed in that case, with `Body` and `GetBody` restored so the payload is still sent downstream.

## Why

`net/http` only populates `GetBody` on client requests. Requests forwarded by a reverse proxy, such as Grafana's datasource proxy (`/api/datasources/proxy/...`), are cloned inbound server requests with `Body` set and `GetBody` nil. Since the migration to this middleware in Grafana 12.1.0 (grafana/grafana#107522), every SigV4-signed POST through the datasource proxy has been signed with the empty-body payload hash while sending a non-empty body, so AWS rejects it with 403 `SignatureDoesNotMatch`. Frontend-only datasource plugins querying OpenSearch/Elasticsearch `_msearch` through the proxy are broken on Grafana >= 12.1.0 as a result (worked on <= 12.0.x with the old aws-sdk-go v1 signer, which hashed the actual body).

The empty-hash fallback was added in #262 to fix a panic, which this change preserves for genuinely bodyless requests (`Body` nil or `http.NoBody`).

## User-facing impact

Fixes 403 SigV4 signature-mismatch errors for any datasource POSTing a body through Grafana's datasource proxy with SigV4 auth (for example the OpenSearch plugin <= 2.15 Explore/panel path). No behaviour change for requests that already had `GetBody` or no body.