### PR TITLE
Gate Grafana Assume Role external ID on usePerDatasourceExternalId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.5.1
+
+- Gate Grafana Assume Role external ID on `usePerDatasourceExternalId` [#470](https://github.com/grafana/grafana-aws-sdk/pull/470)
+  - STS uses the per-datasource ID only when the bool is `true`
+  - Unset/`false` keeps legacy stack external ID (stored `grafanaExternalId` stays dormant)
+  - Shared helper: `awsds.ResolveGrafanaAssumeRoleExternalID`
+
 ## 1.5.0
 
 - Prefer per-datasource grafanaExternalId for Grafana Assume Role [#468](https://github.com/grafana/grafana-aws-sdk/pull/468)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@ All notable changes to this project will be documented in this file.
 ## 1.5.1
 
 - Gate Grafana Assume Role external ID on `usePerDatasourceExternalId` [#470](https://github.com/grafana/grafana-aws-sdk/pull/470)
-  - STS uses the per-datasource ID only when the bool is `true`
-  - Unset/`false` keeps legacy stack external ID (stored `grafanaExternalId` stays dormant)
-  - Shared helper: `awsds.ResolveGrafanaAssumeRoleExternalID`
 
 ## 1.5.0
 

--- a/pkg/awsauth/auth.go
+++ b/pkg/awsauth/auth.go
@@ -59,13 +59,11 @@ func (rcp *awsConfigProvider) GetConfig(ctx context.Context, authSettings Settin
 	case AuthTypeSharedCreds:
 		options = append(options, authSettings.WithSharedCredentials())
 	case AuthTypeGrafanaAssumeRole:
-		// Prefer per-datasource external ID when set; otherwise fall back to
-		// the stack-level ID from Grafana config (legacy shared isolation).
-		if authSettings.GrafanaExternalID != "" {
-			authSettings.ExternalID = authSettings.GrafanaExternalID
-		} else {
-			authSettings.ExternalID = grafanaAuthSettings.ExternalID
-		}
+		authSettings.ExternalID = awsds.ResolveGrafanaAssumeRoleExternalID(
+			authSettings.UsePerDatasourceExternalID,
+			authSettings.GrafanaExternalID,
+			grafanaAuthSettings.ExternalID,
+		)
 		options = append(options, authSettings.WithGrafanaAssumeRole(ctx, rcp.client))
 	default:
 		return aws.Config{}, backend.DownstreamErrorf("unknown auth type: %s", authType)

--- a/pkg/awsauth/auth_test.go
+++ b/pkg/awsauth/auth_test.go
@@ -69,10 +69,11 @@ func (tc testCase) Run(t *testing.T) {
 				assert.Equal(t, tc.authSettings.SessionToken, creds.SessionToken)
 			}
 			if tc.authSettings.GetAuthType() == AuthTypeGrafanaAssumeRole {
-				expectedExternalID := StackID
-				if tc.authSettings.GrafanaExternalID != "" {
-					expectedExternalID = tc.authSettings.GrafanaExternalID
-				}
+				expectedExternalID := awsds.ResolveGrafanaAssumeRoleExternalID(
+					tc.authSettings.UsePerDatasourceExternalID,
+					tc.authSettings.GrafanaExternalID,
+					StackID,
+				)
 				assert.Equal(t, expectedExternalID, client.assumeRoleClient.calledExternalId)
 			} else if tc.authSettings.AssumeRoleARN != "" && tc.authSettings.ExternalID != "" {
 				assert.Equal(t, client.assumeRoleClient.calledExternalId, tc.authSettings.ExternalID)
@@ -373,11 +374,12 @@ func TestGetAWSConfig_Shared(t *testing.T) {
 			},
 		},
 		{
-			name: "grafana assume role prefers per-datasource external ID over stack ID",
+			name: "grafana assume role prefers per-datasource external ID when enabled",
 			authSettings: Settings{
-				AuthType:          AuthTypeGrafanaAssumeRole,
-				AssumeRoleARN:     "arn:aws:iam::1234567890:role/customer-role",
-				GrafanaExternalID: "stackABC-dsUid1",
+				AuthType:                       AuthTypeGrafanaAssumeRole,
+				AssumeRoleARN:                  "arn:aws:iam::1234567890:role/customer-role",
+				GrafanaExternalID:              "stackABC-dsUid1",
+				UsePerDatasourceExternalID:     boolPtr(true),
 				// Cross-account externalId must not be used for this auth type
 				ExternalID: "should-be-ignored",
 			},
@@ -391,7 +393,46 @@ func TestGetAWSConfig_Shared(t *testing.T) {
 				Expiration:      aws.Time(time.Now().Add(time.Hour)),
 			},
 		},
+		{
+			name: "grafana assume role uses stack ID when per-datasource mode is disabled",
+			authSettings: Settings{
+				AuthType:                   AuthTypeGrafanaAssumeRole,
+				AssumeRoleARN:              "arn:aws:iam::1234567890:role/customer-role",
+				GrafanaExternalID:          "stackABC-dsUid1",
+				UsePerDatasourceExternalID: boolPtr(false),
+			},
+			environment: map[string]string{
+				"AWS_SHARED_CREDENTIALS_FILE": testDataPath("assume_role_credentials"),
+			},
+			assumedCredentials: &ststypes.Credentials{
+				AccessKeyId:     aws.String("horses"),
+				SecretAccessKey: aws.String("unicorns"),
+				SessionToken:    aws.String("riding"),
+				Expiration:      aws.Time(time.Now().Add(time.Hour)),
+			},
+		},
+		{
+			name: "grafana assume role uses per-datasource ID when bool unset (legacy)",
+			authSettings: Settings{
+				AuthType:          AuthTypeGrafanaAssumeRole,
+				AssumeRoleARN:     "arn:aws:iam::1234567890:role/customer-role",
+				GrafanaExternalID: "stackABC-dsUid1",
+			},
+			environment: map[string]string{
+				"AWS_SHARED_CREDENTIALS_FILE": testDataPath("assume_role_credentials"),
+			},
+			assumedCredentials: &ststypes.Credentials{
+				AccessKeyId:     aws.String("horses"),
+				SecretAccessKey: aws.String("unicorns"),
+				SessionToken:    aws.String("riding"),
+				Expiration:      aws.Time(time.Now().Add(time.Hour)),
+			},
+		},
 	}.runAll(t)
+}
+
+func boolPtr(v bool) *bool {
+	return &v
 }
 
 func TestGetAWSConfig_UnknownOrMissing(t *testing.T) {

--- a/pkg/awsauth/auth_test.go
+++ b/pkg/awsauth/auth_test.go
@@ -412,7 +412,7 @@ func TestGetAWSConfig_Shared(t *testing.T) {
 			},
 		},
 		{
-			name: "grafana assume role uses per-datasource ID when bool unset (legacy)",
+			name: "grafana assume role uses stack ID when bool unset even if per-DS ID is stored (legacy)",
 			authSettings: Settings{
 				AuthType:          AuthTypeGrafanaAssumeRole,
 				AssumeRoleARN:     "arn:aws:iam::1234567890:role/customer-role",

--- a/pkg/awsauth/auth_test.go
+++ b/pkg/awsauth/auth_test.go
@@ -69,10 +69,11 @@ func (tc testCase) Run(t *testing.T) {
 				assert.Equal(t, tc.authSettings.SessionToken, creds.SessionToken)
 			}
 			if tc.authSettings.GetAuthType() == AuthTypeGrafanaAssumeRole {
+				stackExternalID := grafanaCfg[awsds.GrafanaAssumeRoleExternalIdKeyName]
 				expectedExternalID := awsds.ResolveGrafanaAssumeRoleExternalID(
 					tc.authSettings.UsePerDatasourceExternalID,
 					tc.authSettings.GrafanaExternalID,
-					StackID,
+					stackExternalID,
 				)
 				assert.Equal(t, expectedExternalID, client.assumeRoleClient.calledExternalId)
 			} else if tc.authSettings.AssumeRoleARN != "" && tc.authSettings.ExternalID != "" {
@@ -380,8 +381,10 @@ func TestGetAWSConfig_Shared(t *testing.T) {
 				AssumeRoleARN:              "arn:aws:iam::1234567890:role/customer-role",
 				GrafanaExternalID:          "stackABC-dsUid1",
 				UsePerDatasourceExternalID: boolPtr(true),
-				// Cross-account externalId must not be used for this auth type
-				ExternalID: "should-be-ignored",
+			},
+			// Stack ID always comes from Grafana config for this auth type.
+			grafanaConfig: map[string]string{
+				awsds.GrafanaAssumeRoleExternalIdKeyName: "stack-external-id",
 			},
 			environment: map[string]string{
 				"AWS_SHARED_CREDENTIALS_FILE": testDataPath("assume_role_credentials"),
@@ -401,6 +404,9 @@ func TestGetAWSConfig_Shared(t *testing.T) {
 				GrafanaExternalID:          "stackABC-dsUid1",
 				UsePerDatasourceExternalID: boolPtr(false),
 			},
+			grafanaConfig: map[string]string{
+				awsds.GrafanaAssumeRoleExternalIdKeyName: "stack-external-id",
+			},
 			environment: map[string]string{
 				"AWS_SHARED_CREDENTIALS_FILE": testDataPath("assume_role_credentials"),
 			},
@@ -417,6 +423,9 @@ func TestGetAWSConfig_Shared(t *testing.T) {
 				AuthType:          AuthTypeGrafanaAssumeRole,
 				AssumeRoleARN:     "arn:aws:iam::1234567890:role/customer-role",
 				GrafanaExternalID: "stackABC-dsUid1",
+			},
+			grafanaConfig: map[string]string{
+				awsds.GrafanaAssumeRoleExternalIdKeyName: "stack-external-id",
 			},
 			environment: map[string]string{
 				"AWS_SHARED_CREDENTIALS_FILE": testDataPath("assume_role_credentials"),

--- a/pkg/awsauth/auth_test.go
+++ b/pkg/awsauth/auth_test.go
@@ -376,10 +376,10 @@ func TestGetAWSConfig_Shared(t *testing.T) {
 		{
 			name: "grafana assume role prefers per-datasource external ID when enabled",
 			authSettings: Settings{
-				AuthType:                       AuthTypeGrafanaAssumeRole,
-				AssumeRoleARN:                  "arn:aws:iam::1234567890:role/customer-role",
-				GrafanaExternalID:              "stackABC-dsUid1",
-				UsePerDatasourceExternalID:     boolPtr(true),
+				AuthType:                   AuthTypeGrafanaAssumeRole,
+				AssumeRoleARN:              "arn:aws:iam::1234567890:role/customer-role",
+				GrafanaExternalID:          "stackABC-dsUid1",
+				UsePerDatasourceExternalID: boolPtr(true),
 				// Cross-account externalId must not be used for this auth type
 				ExternalID: "should-be-ignored",
 			},

--- a/pkg/awsauth/settings.go
+++ b/pkg/awsauth/settings.go
@@ -75,12 +75,15 @@ type Settings struct {
 	CredentialsProfile string
 	AssumeRoleARN      string
 	Endpoint           string
-	ExternalID         string
+	ExternalID string
 	// GrafanaExternalID is the per-datasource external ID for
-	// AuthTypeGrafanaAssumeRole. Prefer this over the stack-level ExternalID
-	// from Grafana config when set.
+	// AuthTypeGrafanaAssumeRole. Used when UsePerDatasourceExternalID is true
+	// (or unset with a stored ID — legacy).
 	GrafanaExternalID string
-	UserAgent         string
+	// UsePerDatasourceExternalID selects per-datasource vs stack external ID.
+	// Nil means unset (legacy preference based on GrafanaExternalID presence).
+	UsePerDatasourceExternalID *bool
+	UserAgent                  string
 	SessionToken      string
 	HTTPClient        *http.Client
 	ProxyOptions      *proxy.Options
@@ -105,6 +108,15 @@ func (s Settings) Hash() uint64 {
 	_, _ = h.Write([]byte(s.Endpoint))
 	_, _ = h.Write([]byte(s.ExternalID))
 	_, _ = h.Write([]byte(s.GrafanaExternalID))
+	if s.UsePerDatasourceExternalID != nil {
+		if *s.UsePerDatasourceExternalID {
+			_, _ = h.Write([]byte{1})
+		} else {
+			_, _ = h.Write([]byte{0})
+		}
+	} else {
+		_, _ = h.Write([]byte{2})
+	}
 	if s.PerDatasourceProxySettings != nil {
 		_, _ = h.Write([]byte(s.PerDatasourceProxySettings.ProxyType))
 		_, _ = h.Write([]byte(s.PerDatasourceProxySettings.ProxyUrl))

--- a/pkg/awsauth/settings.go
+++ b/pkg/awsauth/settings.go
@@ -77,11 +77,10 @@ type Settings struct {
 	Endpoint           string
 	ExternalID string
 	// GrafanaExternalID is the per-datasource external ID for
-	// AuthTypeGrafanaAssumeRole. Used when UsePerDatasourceExternalID is true
-	// (or unset with a stored ID — legacy).
+	// AuthTypeGrafanaAssumeRole. Used only when UsePerDatasourceExternalID is true.
 	GrafanaExternalID string
 	// UsePerDatasourceExternalID selects per-datasource vs stack external ID.
-	// Nil means unset (legacy preference based on GrafanaExternalID presence).
+	// Nil/false → stack (legacy). True → use GrafanaExternalID when set.
 	UsePerDatasourceExternalID *bool
 	UserAgent                  string
 	SessionToken      string

--- a/pkg/awsauth/settings.go
+++ b/pkg/awsauth/settings.go
@@ -75,7 +75,7 @@ type Settings struct {
 	CredentialsProfile string
 	AssumeRoleARN      string
 	Endpoint           string
-	ExternalID string
+	ExternalID         string
 	// GrafanaExternalID is the per-datasource external ID for
 	// AuthTypeGrafanaAssumeRole. Used only when UsePerDatasourceExternalID is true.
 	GrafanaExternalID string
@@ -83,9 +83,9 @@ type Settings struct {
 	// Nil/false → stack (legacy). True → use GrafanaExternalID when set.
 	UsePerDatasourceExternalID *bool
 	UserAgent                  string
-	SessionToken      string
-	HTTPClient        *http.Client
-	ProxyOptions      *proxy.Options
+	SessionToken               string
+	HTTPClient                 *http.Client
+	ProxyOptions               *proxy.Options
 
 	PerDatasourceProxySettings *PerDatasourceProxySettings
 }

--- a/pkg/awsauth/settings.go
+++ b/pkg/awsauth/settings.go
@@ -107,14 +107,10 @@ func (s Settings) Hash() uint64 {
 	_, _ = h.Write([]byte(s.Endpoint))
 	_, _ = h.Write([]byte(s.ExternalID))
 	_, _ = h.Write([]byte(s.GrafanaExternalID))
-	if s.UsePerDatasourceExternalID != nil {
-		if *s.UsePerDatasourceExternalID {
-			_, _ = h.Write([]byte{1})
-		} else {
-			_, _ = h.Write([]byte{0})
-		}
+	if s.UsePerDatasourceExternalID != nil && *s.UsePerDatasourceExternalID {
+		_, _ = h.Write([]byte{1})
 	} else {
-		_, _ = h.Write([]byte{2})
+		_, _ = h.Write([]byte{0})
 	}
 	if s.PerDatasourceProxySettings != nil {
 		_, _ = h.Write([]byte(s.PerDatasourceProxySettings.ProxyType))

--- a/pkg/awsds/external_id.go
+++ b/pkg/awsds/external_id.go
@@ -1,0 +1,21 @@
+package awsds
+
+// PreferGrafanaExternalID reports whether Grafana Assume Role should use the
+// per-datasource external ID. An explicit usePerDatasourceExternalId value
+// wins; when unset, a stored grafanaExternalId means per-DS mode (legacy).
+func PreferGrafanaExternalID(usePerDatasourceExternalID *bool, grafanaExternalID string) bool {
+	if usePerDatasourceExternalID != nil {
+		return *usePerDatasourceExternalID
+	}
+	return grafanaExternalID != ""
+}
+
+// ResolveGrafanaAssumeRoleExternalID returns the external ID for Grafana
+// Assume Role: the per-datasource ID when preferred and set, otherwise the
+// stack-level ID.
+func ResolveGrafanaAssumeRoleExternalID(usePerDatasourceExternalID *bool, grafanaExternalID, stackExternalID string) string {
+	if PreferGrafanaExternalID(usePerDatasourceExternalID, grafanaExternalID) && grafanaExternalID != "" {
+		return grafanaExternalID
+	}
+	return stackExternalID
+}

--- a/pkg/awsds/external_id.go
+++ b/pkg/awsds/external_id.go
@@ -1,13 +1,11 @@
 package awsds
 
 // PreferGrafanaExternalID reports whether Grafana Assume Role should use the
-// per-datasource external ID. An explicit usePerDatasourceExternalId value
-// wins; when unset, a stored grafanaExternalId means per-DS mode (legacy).
-func PreferGrafanaExternalID(usePerDatasourceExternalID *bool, grafanaExternalID string) bool {
-	if usePerDatasourceExternalID != nil {
-		return *usePerDatasourceExternalID
-	}
-	return grafanaExternalID != ""
+// per-datasource external ID. Only an explicit usePerDatasourceExternalId=true
+// enables that mode. When the bool is unset or false, use the stack external ID
+// (legacy shared isolation), even if a dormant grafanaExternalId is stored.
+func PreferGrafanaExternalID(usePerDatasourceExternalID *bool, _ string) bool {
+	return usePerDatasourceExternalID != nil && *usePerDatasourceExternalID
 }
 
 // ResolveGrafanaAssumeRoleExternalID returns the external ID for Grafana

--- a/pkg/awsds/external_id.go
+++ b/pkg/awsds/external_id.go
@@ -1,18 +1,12 @@
 package awsds
 
-// PreferGrafanaExternalID reports whether Grafana Assume Role should use the
-// per-datasource external ID. Only an explicit usePerDatasourceExternalId=true
-// enables that mode. When the bool is unset or false, use the stack external ID
-// (legacy shared isolation), even if a dormant grafanaExternalId is stored.
-func PreferGrafanaExternalID(usePerDatasourceExternalID *bool, _ string) bool {
-	return usePerDatasourceExternalID != nil && *usePerDatasourceExternalID
-}
-
 // ResolveGrafanaAssumeRoleExternalID returns the external ID for Grafana
-// Assume Role: the per-datasource ID when preferred and set, otherwise the
-// stack-level ID.
+// Assume Role. When usePerDatasourceExternalID is explicitly true and
+// grafanaExternalID is set, that value is used; otherwise the stack-level ID
+// is returned (legacy shared isolation), even if a dormant grafanaExternalID
+// is stored.
 func ResolveGrafanaAssumeRoleExternalID(usePerDatasourceExternalID *bool, grafanaExternalID, stackExternalID string) string {
-	if PreferGrafanaExternalID(usePerDatasourceExternalID, grafanaExternalID) && grafanaExternalID != "" {
+	if usePerDatasourceExternalID != nil && *usePerDatasourceExternalID && grafanaExternalID != "" {
 		return grafanaExternalID
 	}
 	return stackExternalID

--- a/pkg/awsds/external_id_test.go
+++ b/pkg/awsds/external_id_test.go
@@ -6,17 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPreferGrafanaExternalID(t *testing.T) {
-	trueVal := true
-	falseVal := false
-
-	assert.True(t, PreferGrafanaExternalID(&trueVal, "stack-uid"))
-	assert.False(t, PreferGrafanaExternalID(&falseVal, "stack-uid"))
-	assert.False(t, PreferGrafanaExternalID(&falseVal, ""))
-	assert.False(t, PreferGrafanaExternalID(nil, "stack-uid"))
-	assert.False(t, PreferGrafanaExternalID(nil, ""))
-}
-
 func TestResolveGrafanaAssumeRoleExternalID(t *testing.T) {
 	trueVal := true
 	falseVal := false

--- a/pkg/awsds/external_id_test.go
+++ b/pkg/awsds/external_id_test.go
@@ -13,7 +13,7 @@ func TestPreferGrafanaExternalID(t *testing.T) {
 	assert.True(t, PreferGrafanaExternalID(&trueVal, "stack-uid"))
 	assert.False(t, PreferGrafanaExternalID(&falseVal, "stack-uid"))
 	assert.False(t, PreferGrafanaExternalID(&falseVal, ""))
-	assert.True(t, PreferGrafanaExternalID(nil, "stack-uid"))
+	assert.False(t, PreferGrafanaExternalID(nil, "stack-uid"))
 	assert.False(t, PreferGrafanaExternalID(nil, ""))
 }
 
@@ -24,6 +24,6 @@ func TestResolveGrafanaAssumeRoleExternalID(t *testing.T) {
 	assert.Equal(t, "stack-uid", ResolveGrafanaAssumeRoleExternalID(&trueVal, "stack-uid", "stack"))
 	assert.Equal(t, "stack", ResolveGrafanaAssumeRoleExternalID(&falseVal, "stack-uid", "stack"))
 	assert.Equal(t, "stack", ResolveGrafanaAssumeRoleExternalID(&trueVal, "", "stack"))
-	assert.Equal(t, "stack-uid", ResolveGrafanaAssumeRoleExternalID(nil, "stack-uid", "stack"))
+	assert.Equal(t, "stack", ResolveGrafanaAssumeRoleExternalID(nil, "stack-uid", "stack"))
 	assert.Equal(t, "stack", ResolveGrafanaAssumeRoleExternalID(nil, "", "stack"))
 }

--- a/pkg/awsds/external_id_test.go
+++ b/pkg/awsds/external_id_test.go
@@ -1,0 +1,29 @@
+package awsds
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPreferGrafanaExternalID(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
+	assert.True(t, PreferGrafanaExternalID(&trueVal, "stack-uid"))
+	assert.False(t, PreferGrafanaExternalID(&falseVal, "stack-uid"))
+	assert.False(t, PreferGrafanaExternalID(&falseVal, ""))
+	assert.True(t, PreferGrafanaExternalID(nil, "stack-uid"))
+	assert.False(t, PreferGrafanaExternalID(nil, ""))
+}
+
+func TestResolveGrafanaAssumeRoleExternalID(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
+	assert.Equal(t, "stack-uid", ResolveGrafanaAssumeRoleExternalID(&trueVal, "stack-uid", "stack"))
+	assert.Equal(t, "stack", ResolveGrafanaAssumeRoleExternalID(&falseVal, "stack-uid", "stack"))
+	assert.Equal(t, "stack", ResolveGrafanaAssumeRoleExternalID(&trueVal, "", "stack"))
+	assert.Equal(t, "stack-uid", ResolveGrafanaAssumeRoleExternalID(nil, "stack-uid", "stack"))
+	assert.Equal(t, "stack", ResolveGrafanaAssumeRoleExternalID(nil, "", "stack"))
+}

--- a/pkg/awsds/settings.go
+++ b/pkg/awsds/settings.go
@@ -98,9 +98,14 @@ type AWSDatasourceSettings struct {
 	AssumeRoleARN string   `json:"assumeRoleARN"`
 	ExternalID    string   `json:"externalId"`
 	// GrafanaExternalID is the per-datasource external ID used for
-	// AuthTypeGrafanaAssumeRole. When empty, auth falls back to the stack-level
-	// AWS_AUTH_EXTERNAL_ID. Do not reuse ExternalID for this purpose.
+	// AuthTypeGrafanaAssumeRole when UsePerDatasourceExternalID is true (or
+	// when the bool is unset and this field is set — legacy). Do not reuse
+	// ExternalID for this purpose.
 	GrafanaExternalID string `json:"grafanaExternalId,omitempty"`
+	// UsePerDatasourceExternalID selects per-datasource vs stack external ID
+	// for Grafana Assume Role. Nil means unset (legacy: prefer GrafanaExternalID
+	// when present). False keeps a stored GrafanaExternalID dormant.
+	UsePerDatasourceExternalID *bool `json:"usePerDatasourceExternalId,omitempty"`
 
 	// Override the client endpoint
 	Endpoint string `json:"endpoint"`

--- a/pkg/awsds/settings.go
+++ b/pkg/awsds/settings.go
@@ -98,13 +98,13 @@ type AWSDatasourceSettings struct {
 	AssumeRoleARN string   `json:"assumeRoleARN"`
 	ExternalID    string   `json:"externalId"`
 	// GrafanaExternalID is the per-datasource external ID used for
-	// AuthTypeGrafanaAssumeRole when UsePerDatasourceExternalID is true (or
-	// when the bool is unset and this field is set — legacy). Do not reuse
-	// ExternalID for this purpose.
+	// AuthTypeGrafanaAssumeRole when UsePerDatasourceExternalID is true.
+	// When the bool is unset/false, auth uses the stack external ID even if
+	// this field is stored (dormant). Do not reuse ExternalID for this purpose.
 	GrafanaExternalID string `json:"grafanaExternalId,omitempty"`
 	// UsePerDatasourceExternalID selects per-datasource vs stack external ID
-	// for Grafana Assume Role. Nil means unset (legacy: prefer GrafanaExternalID
-	// when present). False keeps a stored GrafanaExternalID dormant.
+	// for Grafana Assume Role. Nil/false → stack (legacy). True → use
+	// GrafanaExternalID when set.
 	UsePerDatasourceExternalID *bool `json:"usePerDatasourceExternalId,omitempty"`
 
 	// Override the client endpoint


### PR DESCRIPTION
## Summary
- Add `UsePerDatasourceExternalID` to awsds/awsauth settings
- STS uses per-datasource ID only when the bool is **true**
- Unset/`false` keeps legacy stack external ID; a stored `grafanaExternalId` stays dormant
- Shared helper: `awsds.ResolveGrafanaAssumeRoleExternalID`
- CHANGELOG: 1.5.1

Related: grafana/oss-plugin-partnerships#1473

## Test plan
- [x] `gofmt` clean on touched packages
- [x] `go test ./pkg/awsds/ ./pkg/awsauth/`
- [ ] Downstream: grafana / CloudWatch / enterprise pass the bool through

## Note
Supersedes presence-only dual-read from v1.5.0 for mode switching without reminting.