### PR TITLE
chore(metrics): Add missing metrics for Route 53 Resolver

### DIFF
--- a/pkg/cloudWatchConsts/metrics.go
+++ b/pkg/cloudWatchConsts/metrics.go
@@ -2983,9 +2983,12 @@ var NamespaceMetricsMap = map[string][]string{
 		"TimeToFirstByte",
 	},
 	"AWS/Route53Resolver": {
+		"EndpointHealthyENICount",
+		"EndpointUnhealthyENICount",
 		"InboundQueryVolume",
 		"OutboundQueryAggregateVolume",
 		"OutboundQueryVolume",
+		"ResolverEndpointCapacityStatus",
 	},
 	"AWS/S3": {
 		"4xxErrors",


### PR DESCRIPTION
## What

Adds the three Route 53 Resolver endpoint metrics — `EndpointHealthyENICount`, `EndpointUnhealthyENICount`, and `ResolverEndpointCapacityStatus` — to the `AWS/Route53Resolver` namespace metric list.

## Why

AWS publishes these per-endpoint metrics under `AWS/Route53Resolver`, keyed by the `EndpointId` dimension — see [Monitoring Route 53 Resolver endpoints with Amazon CloudWatch](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/monitoring-resolver-with-cloudwatch.html). None of the three are in `NamespaceMetricsMap["AWS/Route53Resolver"]` today, so they aren't suggested in the CloudWatch query editor's metric list. They are also the metrics named by the unchecked metrics checklist item in grafana/grafana-csp-app#345 (the Route 53 / Route 53 Resolver dashboards issue, closed with that item, and both alert items, still unchecked). Same shape as previous metric additions (#477, #479).

## Notes for the reviewer

- All three are default metrics for Resolver endpoints: AWS sends them to CloudWatch automatically at five-minute intervals, free of cost — no opt-in needed on the AWS side.
- `EndpointId` is already registered in `NamespaceDimensionKeysMap["AWS/Route53Resolver"]`, so no dimension change is needed.
- `ResolverEndpointCapacityStatus` encodes the current capacity-utilization state — 0 = OK, 1 = Warning (at least one ENI exceeds 50% capacity utilization), 2 = Critical (exceeds 75%) — and AWS lists `Maximum` as its only valid statistic; the two ENI-count metrics take Minimum/Maximum/Average.
- The doc's opt-in detailed metric sets (P90ResponseTime, ServFailQueries, etc., with additional dimension sets including `RniId`/`TargetNameServerIP`) are deliberately excluded here — different opt-in model and cadence; happy to follow up separately if there's appetite.
- Downstream note: consumers that default inherited metrics to an `Average` statistic (the hosted AWS integration's exporter does) will want a `Maximum` override for `ResolverEndpointCapacityStatus` when picking up a release with this change — averaging mixed 0/1/2 status samples can mask a Critical sample.

## Testing

`TestNamespaceMetricsAlphabetized` covers ordering of the additions; no new tests — constants-only change, per repo precedent (#477, #479). Locally green: `golangci-lint run` (v2.8.0), `go test -race ./...`, `go build ./...`, `govulncheck ./...`, `gofmt -l` clean.

---

This PR implements a customer request from Grafana's Voice of Customer (VoC) program (ref IDEASVOC-I-9799). It was prepared with AI assistance as part of an internal VoC→PR pilot and human-reviewed before submission; I'm the accountable author and will handle review feedback.
