### PR TITLE
fix: bump go to 1.26.6 to address stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-aws-sdk
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.0


### PR DESCRIPTION
## Problem

`go-check` is currently failing on every branch, including `main` and unrelated Renovate PRs. It last passed on `main` on 10 Aug. The cause is five Go standard library vulnerabilities disclosed since then, all of which are fixed in go1.26.6:

| Vulnerability | Package |
| --- | --- |
| GO-2026-6218 | `net/url` |
| GO-2026-6090 | `crypto/tls` |
| GO-2026-6088 | `encoding/xml` |
| GO-2026-5972 | `encoding/asn1` |
| GO-2026-5026 | `net/http` |

The workflow resolves its Go version with `setup-go`'s `go-version-file: 'go.mod'`, so it was building against the `go 1.26.5` directive and picking up the unpatched standard library. None of the reported call traces are new code; they run through long-standing paths such as `pkg/awsauth/sigv4.go` and `pkg/sql/routes/routes.go`.

Because the govulncheck step runs before Test and Build, the job fails before the test suite executes at all, so this is masking test results across the repo.

## Change

Bumps the `go` directive from 1.26.5 to 1.26.6. This is the only Go version reference in the repo.

## Verification

Locally against this branch:

- `govulncheck ./...` reports `No vulnerabilities found` / affected by 0 vulnerabilities, down from 5.
- `golangci-lint run --timeout=5m` reports 0 issues.
- `go build ./...` and `go test ./...` both pass.

I confirmed the same five findings reproduce on 1.26.5 and disappear on 1.26.6, so the bump is what clears them rather than an unrelated change.

## Note for reviewers

This uses the `go` directive rather than `toolchain`, so it does raise the minimum Go version for consumers of the library. That should not block anyone: `grafana/grafana` is already on `go 1.26.6` as of grafana/grafana#130724 (14 Aug), where core bumped for these same standard library CVEs.

The only place the floor still matters is release branches, which are on `go 1.26.5` (`release-12.4.6` through `release-12.4.9`), so a backport of any release carrying this would need its own Go bump first.